### PR TITLE
Add csv2parquet tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,28 @@ it follows some conventions. In particular, it has to contain only a single
 fields, one named `key`, the other named `value`. This represents a map
 structure in which each key is associated with one value.
 
+## Tools
+
+`parquet-go` comes with tooling to inspect and generate parquet tools.
+
+### parquet-tool
+
+`parquet-tool` allows you to inspect the meta data, the schema and the number of rows
+as well as print the content of a parquet file. You can also use it to split an existing
+parquet file into multiple smaller files.
+
+Install it by running `go get github.com/fraugster/parquet-go/cmd/parquet-tool` on your command line.
+For more detailed help on how to use the tool, consult `parquet-tool --help`.
+
+### csv2parquet
+
+`csv2parquet` makes it possible to convert an existing CSV file into a parquet file. By default,
+all columns are simply turned into strings, but you provide it with type hints to influence
+the generated parquet schema.
+
+You can install this tool by running `go get github.com/fraugster/parquet-go/cmd/csv2parquet` on your command line.
+For more help, consult `csv2parquet --help`.
+
 ## Contributing
 
 If you want to hack on this repository, please read the short [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/cmd/csv2parquet/main.go
+++ b/cmd/csv2parquet/main.go
@@ -258,11 +258,14 @@ func parseTypeHints(s string) (map[string]string, error) {
 			return nil, fmt.Errorf("invalid type hint %q", hint)
 		}
 
-		if !isValidType(hintFields[1]) {
-			return nil, fmt.Errorf("invalid parquet type %q", hintFields[1])
+		fieldName := strings.TrimSpace(hintFields[0])
+		fieldType := strings.TrimSpace(hintFields[1])
+
+		if !isValidType(fieldType) {
+			return nil, fmt.Errorf("invalid parquet type %q", fieldType)
 		}
 
-		typeMap[hintFields[0]] = hintFields[1]
+		typeMap[fieldName] = fieldType
 	}
 
 	return typeMap, nil

--- a/cmd/csv2parquet/main.go
+++ b/cmd/csv2parquet/main.go
@@ -25,7 +25,7 @@ func main() {
 	inputFile := flag.String("input", "", "CSV file input")
 	typeHints := flag.String("typehints", "", "type hints to help derive parquet schema. A comma-separated list of type hints in the format <column_name>=<parquettype>; valid parquet types: "+strings.Join(validTypeList(), ", "))
 	outputFile := flag.String("output", "", "output parquet file")
-	rowgroupSize := flag.Int64("rowgroup-size", 0, "row group size in bytes; if value is 0, then the row group size is unbounded")
+	rowgroupSize := flag.Int64("rowgroup-size", 100*1024*1024, "row group size in bytes; if value is 0, then the row group size is unbounded")
 	compressionCodec := flag.String("compression", "snappy", "compression algorithm; allowed values: "+strings.Join(validCompressionCodecs(), ", "))
 	delimiter := flag.String("delimiter", ",", "CSV field delimiter")
 	creator := flag.String("created-by", "csv2parquet", "value to set for CreatedBy field of parquet file")

--- a/cmd/csv2parquet/main.go
+++ b/cmd/csv2parquet/main.go
@@ -61,7 +61,7 @@ func main() {
 		log.Fatalf("Parsing type hints failed: %v", err)
 	}
 
-	log.Printf("Opening %s...", *inputFile)
+	printLog("Opening %s...", *inputFile)
 
 	f, err := os.Open(*inputFile)
 	if err != nil {
@@ -84,7 +84,7 @@ func main() {
 	header := records[0]
 	records = records[1:]
 
-	log.Printf("Finished reading %s, got %d records", *inputFile, len(records))
+	printLog("Finished reading %s, got %d records", *inputFile, len(records))
 
 	schema := &parquetschema.SchemaDefinition{
 		RootColumn: &parquetschema.ColumnDefinition{
@@ -199,7 +199,7 @@ func main() {
 		log.Fatalf("Internal error: derived schema does not validate: %v\nschema: %s", err, schema.String())
 	}
 
-	log.Printf("Derived parquet schema: %s", schema.String())
+	printLog("Derived parquet schema: %s", schema.String())
 
 	of, err := os.OpenFile(*outputFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
@@ -239,7 +239,7 @@ func main() {
 		log.Fatalf("Closing parquet writer failed: %v", err)
 	}
 
-	log.Printf("Finished generating output file %s", *outputFile)
+	printLog("Finished generating output file %s", *outputFile)
 }
 
 func parseTypeHints(s string) (map[string]string, error) {
@@ -288,7 +288,7 @@ var validTypes = map[string]bool{
 }
 
 func validTypeList() []string {
-	var l []string
+	l := make([]string, 0, len(validTypes))
 	for k := range validTypes {
 		l = append(l, k)
 	}
@@ -303,7 +303,7 @@ var validCodecs = map[string]parquet.CompressionCodec{
 }
 
 func validCompressionCodecs() []string {
-	var l []string
+	l := make([]string, 0, len(validCodecs))
 	for k := range validCodecs {
 		l = append(l, k)
 	}

--- a/cmd/csv2parquet/main.go
+++ b/cmd/csv2parquet/main.go
@@ -275,6 +275,8 @@ func createColumn(field, typ string) (col *parquetschema.ColumnDefinition, field
 		return nil, nil, fmt.Errorf("unsupported type %q", typ)
 	}
 
+	fieldHandler = optionalHandler(fieldHandler) // TODO: if we make repetition type configurable, change this to use correct handler.
+
 	return col, fieldHandler, nil
 }
 
@@ -421,4 +423,13 @@ func jsonHandler(s string) (interface{}, error) {
 		return nil, err
 	}
 	return data, nil
+}
+
+func optionalHandler(next fieldHandler) fieldHandler {
+	return func(s string) (interface{}, error) {
+		if s == "" {
+			return nil, nil
+		}
+		return next(s)
+	}
 }

--- a/cmd/csv2parquet/main.go
+++ b/cmd/csv2parquet/main.go
@@ -27,7 +27,7 @@ func main() {
 	outputFile := flag.String("output", "", "output parquet file")
 	rowgroupSize := flag.Int64("rowgroup-size", 0, "row group size in bytes; if value is 0, then the row group size is unbounded")
 	compressionCodec := flag.String("compression", "snappy", "compression algorithm; allowed values: "+strings.Join(validCompressionCodecs(), ", "))
-	delimiter := flag.String("delimiter", ",", "CSV field separator")
+	delimiter := flag.String("delimiter", ",", "CSV field delimiter")
 	creator := flag.String("created-by", "csv2parquet", "value to set for CreatedBy field of parquet file")
 	verbose := flag.Bool("v", false, "enable verbose logging")
 	flag.Parse()

--- a/cmd/csv2parquet/main.go
+++ b/cmd/csv2parquet/main.go
@@ -337,27 +337,27 @@ func validTypeList() []string {
 	return l
 }
 
-var validCodecs = map[string]parquet.CompressionCodec{
-	"none":   parquet.CompressionCodec_UNCOMPRESSED,
-	"snappy": parquet.CompressionCodec_SNAPPY,
-	"gzip":   parquet.CompressionCodec_GZIP,
-}
-
 func validCompressionCodecs() []string {
-	l := make([]string, 0, len(validCodecs))
-	for k := range validCodecs {
-		l = append(l, k)
+	registeredCodecs := goparquet.GetRegisteredBlockCompressors()
+
+	l := make([]string, 0, len(registeredCodecs))
+	for k := range registeredCodecs {
+		l = append(l, strings.ToLower(k.String()))
 	}
 	sort.Strings(l)
 	return l
 }
 
 func lookupCompressionCodec(codec string) (parquet.CompressionCodec, error) {
-	c, ok := validCodecs[codec]
-	if !ok {
-		return parquet.CompressionCodec_UNCOMPRESSED, errors.New("unsupported compression codec")
+	registeredCodecs := goparquet.GetRegisteredBlockCompressors()
+
+	for c := range registeredCodecs {
+		if strings.ToLower(c.String()) == codec {
+			return c, nil
+		}
 	}
-	return c, nil
+
+	return parquet.CompressionCodec_UNCOMPRESSED, errors.New("unsupported compression codec")
 }
 
 func isValidType(t string) bool {

--- a/cmd/csv2parquet/main.go
+++ b/cmd/csv2parquet/main.go
@@ -143,7 +143,7 @@ func writeParquetData(of io.Writer, header []string, types map[string]string, re
 	}
 
 	if err := pqWriter.Close(); err != nil {
-		return fmt.Errorf("Closing parquet writer failed: %w", err)
+		return fmt.Errorf("closing parquet writer failed: %w", err)
 	}
 
 	return nil

--- a/cmd/csv2parquet/main.go
+++ b/cmd/csv2parquet/main.go
@@ -104,7 +104,7 @@ func main() {
 func writeParquetData(of io.Writer, header []string, types map[string]string, records [][]string, creator string, codec parquet.CompressionCodec, rowgroupSize int64) error {
 	schema, fieldHandlers, err := deriveSchema(header, types)
 	if err != nil {
-		log.Fatalf("Generating schema failed: %v", err)
+		return fmt.Errorf("generating schema failed: %w", err)
 	}
 
 	printLog("Derived parquet schema: %s", schema.String())
@@ -123,6 +123,11 @@ func writeParquetData(of io.Writer, header []string, types map[string]string, re
 
 	for recordIndex, record := range records {
 		data := make(map[string]interface{})
+
+		if len(record) < len(header) {
+			return fmt.Errorf("input record %d only contains %d fields instead of the expected %d", recordIndex+1, len(record), len(header))
+		}
+
 		for idx, fieldName := range header {
 			handler := fieldHandlers[idx]
 

--- a/cmd/csv2parquet/main.go
+++ b/cmd/csv2parquet/main.go
@@ -1,0 +1,385 @@
+package main
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	goparquet "github.com/fraugster/parquet-go"
+	"github.com/fraugster/parquet-go/parquet"
+	"github.com/fraugster/parquet-go/parquetschema"
+)
+
+var printLog = func(string, ...interface{}) {}
+
+func main() {
+	inputFile := flag.String("input", "", "CSV file input")
+	typeHints := flag.String("typehints", "", "type hints to help derive parquet schema. A comma-separated list of type hints in the format <column_name>=<parquettype>; valid parquet types: "+strings.Join(validTypeList(), ", "))
+	outputFile := flag.String("output", "", "output parquet file")
+	rowgroupSize := flag.Int64("rowgroup-size", 0, "row group size in bytes; if value is 0, then the row group size is unbounded")
+	compressionCodec := flag.String("compression", "snappy", "compression algorithm; allowed values: "+strings.Join(validCompressionCodecs(), ", "))
+	delimiter := flag.String("delimiter", ",", "CSV field separator")
+	verbose := flag.Bool("v", false, "enable verbose logging")
+	flag.Parse()
+
+	if *inputFile == "" {
+		log.Fatalf("Empty input file parameter")
+	}
+
+	if *outputFile == "" {
+		log.Fatalf("Empty output file parameter")
+	}
+
+	codec, err := lookupCompressionCodec(*compressionCodec)
+	if err != nil {
+		log.Fatalf("Invalid compression codec %q: %v", *compressionCodec, err)
+	}
+
+	var delimiterRune rune
+
+	if *delimiter != "" {
+		delimiterRune, _ = utf8.DecodeRuneInString(*delimiter)
+		if delimiterRune == '\r' || delimiterRune == '\n' || delimiterRune == '\uFFFD' {
+			log.Fatalf("Invalid CSV field separator %q", *delimiter)
+		}
+	}
+
+	if *verbose {
+		printLog = log.Printf
+	}
+
+	types, err := parseTypeHints(*typeHints)
+	if err != nil {
+		log.Fatalf("Parsing type hints failed: %v", err)
+	}
+
+	log.Printf("Opening %s...", *inputFile)
+
+	f, err := os.Open(*inputFile)
+	if err != nil {
+		log.Fatalf("Couldn't open input file: %v", err)
+	}
+
+	csvReader := csv.NewReader(f)
+
+	if *delimiter != "" {
+		csvReader.Comma = delimiterRune
+	}
+
+	records, err := csvReader.ReadAll()
+	if err != nil {
+		log.Fatalf("Reading CSV content failed: %v", err)
+	}
+
+	f.Close()
+
+	header := records[0]
+	records = records[1:]
+
+	log.Printf("Finished reading %s, got %d records", *inputFile, len(records))
+
+	schema := &parquetschema.SchemaDefinition{
+		RootColumn: &parquetschema.ColumnDefinition{
+			SchemaElement: &parquet.SchemaElement{
+				Name: "msg",
+			},
+		},
+	}
+
+	fieldHandlers := make([]func(string) (interface{}, error), len(header))
+
+	for idx, field := range header {
+		typ := types[field]
+		if typ == "" {
+			typ = "string"
+			types[field] = typ
+		}
+
+		col := &parquetschema.ColumnDefinition{
+			SchemaElement: &parquet.SchemaElement{},
+		}
+		col.SchemaElement.RepetitionType = parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_OPTIONAL)
+		col.SchemaElement.Name = field
+
+		switch typ {
+		case "string":
+			col.SchemaElement.Type = parquet.TypePtr(parquet.Type_BYTE_ARRAY)
+			col.SchemaElement.LogicalType = parquet.NewLogicalType()
+			col.SchemaElement.LogicalType.STRING = &parquet.StringType{}
+			col.SchemaElement.ConvertedType = parquet.ConvertedTypePtr(parquet.ConvertedType_UTF8)
+			fieldHandlers[idx] = byteArrayHandler
+		case "byte_array":
+			col.SchemaElement.Type = parquet.TypePtr(parquet.Type_BYTE_ARRAY)
+			fieldHandlers[idx] = byteArrayHandler
+		case "boolean":
+			col.SchemaElement.Type = parquet.TypePtr(parquet.Type_BOOLEAN)
+			fieldHandlers[idx] = booleanHandler
+		case "int8":
+			col.SchemaElement.Type = parquet.TypePtr(parquet.Type_INT32)
+			col.SchemaElement.LogicalType = parquet.NewLogicalType()
+			col.SchemaElement.LogicalType.INTEGER = &parquet.IntType{BitWidth: 8, IsSigned: true}
+			col.SchemaElement.ConvertedType = parquet.ConvertedTypePtr(parquet.ConvertedType_INT_8)
+			fieldHandlers[idx] = intHandler(8)
+		case "uint8":
+			col.SchemaElement.Type = parquet.TypePtr(parquet.Type_INT32)
+			col.SchemaElement.LogicalType = parquet.NewLogicalType()
+			col.SchemaElement.LogicalType.INTEGER = &parquet.IntType{BitWidth: 8, IsSigned: false}
+			col.SchemaElement.ConvertedType = parquet.ConvertedTypePtr(parquet.ConvertedType_UINT_8)
+			fieldHandlers[idx] = uintHandler(8)
+		case "int16":
+			col.SchemaElement.Type = parquet.TypePtr(parquet.Type_INT32)
+			col.SchemaElement.LogicalType = parquet.NewLogicalType()
+			col.SchemaElement.LogicalType.INTEGER = &parquet.IntType{BitWidth: 16, IsSigned: true}
+			col.SchemaElement.ConvertedType = parquet.ConvertedTypePtr(parquet.ConvertedType_INT_16)
+			fieldHandlers[idx] = intHandler(16)
+		case "uint16":
+			col.SchemaElement.Type = parquet.TypePtr(parquet.Type_INT32)
+			col.SchemaElement.LogicalType = parquet.NewLogicalType()
+			col.SchemaElement.LogicalType.INTEGER = &parquet.IntType{BitWidth: 16, IsSigned: false}
+			col.SchemaElement.ConvertedType = parquet.ConvertedTypePtr(parquet.ConvertedType_UINT_16)
+			fieldHandlers[idx] = uintHandler(16)
+		case "int32":
+			col.SchemaElement.Type = parquet.TypePtr(parquet.Type_INT32)
+			col.SchemaElement.LogicalType = parquet.NewLogicalType()
+			col.SchemaElement.LogicalType.INTEGER = &parquet.IntType{BitWidth: 32, IsSigned: true}
+			col.SchemaElement.ConvertedType = parquet.ConvertedTypePtr(parquet.ConvertedType_INT_32)
+			fieldHandlers[idx] = intHandler(32)
+		case "uint32":
+			col.SchemaElement.Type = parquet.TypePtr(parquet.Type_INT32)
+			col.SchemaElement.LogicalType = parquet.NewLogicalType()
+			col.SchemaElement.LogicalType.INTEGER = &parquet.IntType{BitWidth: 32, IsSigned: false}
+			col.SchemaElement.ConvertedType = parquet.ConvertedTypePtr(parquet.ConvertedType_UINT_32)
+			fieldHandlers[idx] = uintHandler(32)
+		case "int64":
+			col.SchemaElement.Type = parquet.TypePtr(parquet.Type_INT64)
+			col.SchemaElement.LogicalType = parquet.NewLogicalType()
+			col.SchemaElement.LogicalType.INTEGER = &parquet.IntType{BitWidth: 64, IsSigned: true}
+			col.SchemaElement.ConvertedType = parquet.ConvertedTypePtr(parquet.ConvertedType_INT_64)
+			fieldHandlers[idx] = intHandler(64)
+		case "uint64":
+			col.SchemaElement.Type = parquet.TypePtr(parquet.Type_INT64)
+			col.SchemaElement.LogicalType = parquet.NewLogicalType()
+			col.SchemaElement.LogicalType.INTEGER = &parquet.IntType{BitWidth: 64, IsSigned: false}
+			col.SchemaElement.ConvertedType = parquet.ConvertedTypePtr(parquet.ConvertedType_UINT_64)
+			fieldHandlers[idx] = uintHandler(64)
+		case "float":
+			col.SchemaElement.Type = parquet.TypePtr(parquet.Type_FLOAT)
+			fieldHandlers[idx] = floatHandler
+		case "double":
+			col.SchemaElement.Type = parquet.TypePtr(parquet.Type_DOUBLE)
+			fieldHandlers[idx] = doubleHandler
+		case "int":
+			col.SchemaElement.Type = parquet.TypePtr(parquet.Type_INT64)
+			col.SchemaElement.LogicalType = parquet.NewLogicalType()
+			col.SchemaElement.LogicalType.INTEGER = &parquet.IntType{BitWidth: 64, IsSigned: true}
+			col.SchemaElement.ConvertedType = parquet.ConvertedTypePtr(parquet.ConvertedType_INT_64)
+			fieldHandlers[idx] = intHandler(64)
+		case "json":
+			col.SchemaElement.Type = parquet.TypePtr(parquet.Type_BYTE_ARRAY)
+			col.SchemaElement.LogicalType = parquet.NewLogicalType()
+			col.SchemaElement.LogicalType.JSON = &parquet.JsonType{}
+			col.SchemaElement.ConvertedType = parquet.ConvertedTypePtr(parquet.ConvertedType_JSON)
+			fieldHandlers[idx] = jsonHandler
+		default:
+			log.Fatalf("Unsupport type %q", typ)
+		}
+
+		schema.RootColumn.Children = append(schema.RootColumn.Children, col)
+	}
+
+	if err := schema.Validate(); err != nil {
+		log.Fatalf("Internal error: derived schema does not validate: %v\nschema: %s", err, schema.String())
+	}
+
+	log.Printf("Derived parquet schema: %s", schema.String())
+
+	of, err := os.OpenFile(*outputFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		log.Fatalf("Couldn't open output file: %v", err)
+	}
+	defer of.Close()
+
+	writerOptions := []goparquet.FileWriterOption{
+		goparquet.WithCreator("csv2parquet"),
+		goparquet.WithSchemaDefinition(schema),
+		goparquet.WithCompressionCodec(codec),
+	}
+
+	if *rowgroupSize > 0 {
+		writerOptions = append(writerOptions, goparquet.WithMaxRowGroupSize(*rowgroupSize))
+	}
+
+	pqWriter := goparquet.NewFileWriter(of, writerOptions...)
+
+	for recordIndex, record := range records {
+		data := make(map[string]interface{})
+		for idx, fieldName := range header {
+			handler := fieldHandlers[idx]
+
+			v, err := handler(record[idx])
+			if err != nil {
+				log.Fatalf("In input record %d, couldn't convert value %q to type %s: %v", recordIndex+1, record[idx], types[fieldName], err)
+			}
+			data[fieldName] = v
+		}
+		if err := pqWriter.AddData(data); err != nil {
+			log.Fatalf("In input record %d, adding data failed: %v", recordIndex+1, err)
+		}
+	}
+
+	if err := pqWriter.Close(); err != nil {
+		log.Fatalf("Closing parquet writer failed: %v", err)
+	}
+
+	log.Printf("Finished generating output file %s", *outputFile)
+}
+
+func parseTypeHints(s string) (map[string]string, error) {
+	typeMap := make(map[string]string)
+
+	if s == "" {
+		return typeMap, nil
+	}
+
+	hintsList := strings.Split(s, ",")
+	for _, hint := range hintsList {
+		hint = strings.TrimSpace(hint)
+
+		hintFields := strings.Split(hint, "=")
+		if len(hintFields) != 2 {
+			return nil, fmt.Errorf("invalid type hint %q", hint)
+		}
+
+		if !isValidType(hintFields[1]) {
+			return nil, fmt.Errorf("invalid parquet type %q", hintFields[1])
+		}
+
+		typeMap[hintFields[0]] = hintFields[1]
+	}
+
+	return typeMap, nil
+}
+
+var validTypes = map[string]bool{
+	"boolean":    true,
+	"int8":       true,
+	"uint8":      true,
+	"int16":      true,
+	"uint16":     true,
+	"int32":      true,
+	"uint32":     true,
+	"int64":      true,
+	"uint64":     true,
+	"float":      true,
+	"double":     true,
+	"byte_array": true,
+	"string":     true,
+	"int":        true,
+	"json":       true,
+	// TODO: support more data types
+}
+
+func validTypeList() []string {
+	var l []string
+	for k := range validTypes {
+		l = append(l, k)
+	}
+	sort.Strings(l)
+	return l
+}
+
+var validCodecs = map[string]parquet.CompressionCodec{
+	"none":   parquet.CompressionCodec_UNCOMPRESSED,
+	"snappy": parquet.CompressionCodec_SNAPPY,
+	"gzip":   parquet.CompressionCodec_GZIP,
+}
+
+func validCompressionCodecs() []string {
+	var l []string
+	for k := range validCodecs {
+		l = append(l, k)
+	}
+	sort.Strings(l)
+	return l
+}
+
+func lookupCompressionCodec(codec string) (parquet.CompressionCodec, error) {
+	c, ok := validCodecs[codec]
+	if !ok {
+		return parquet.CompressionCodec_UNCOMPRESSED, errors.New("unsupported compression codec")
+	}
+	return c, nil
+}
+
+func isValidType(t string) bool {
+	return validTypes[t]
+}
+
+func byteArrayHandler(s string) (interface{}, error) {
+	return []byte(s), nil
+}
+
+func booleanHandler(s string) (interface{}, error) {
+	return strconv.ParseBool(s)
+}
+
+func uintHandler(bitSize int) func(string) (interface{}, error) {
+	return func(s string) (interface{}, error) {
+		i, err := strconv.ParseUint(s, 10, bitSize)
+		if err != nil {
+			return nil, err
+		}
+		switch bitSize {
+		case 8, 16, 32:
+			return uint32(i), nil
+		case 64:
+			return i, nil
+		default:
+			return nil, fmt.Errorf("invalid bit size %d", bitSize)
+		}
+	}
+}
+
+func intHandler(bitSize int) func(string) (interface{}, error) {
+	return func(s string) (interface{}, error) {
+		i, err := strconv.ParseInt(s, 10, bitSize)
+		if err != nil {
+			return nil, err
+		}
+		switch bitSize {
+		case 8, 16, 32:
+			return int32(i), nil
+		case 64:
+			return int64(i), nil
+		default:
+			return nil, fmt.Errorf("invalid bit size %d", bitSize)
+		}
+	}
+}
+
+func floatHandler(s string) (interface{}, error) {
+	f, err := strconv.ParseFloat(s, 32)
+	return float32(f), err
+}
+
+func doubleHandler(s string) (interface{}, error) {
+	f, err := strconv.ParseFloat(s, 64)
+	return f, err
+}
+
+func jsonHandler(s string) (interface{}, error) {
+	data := []byte(s)
+	var obj interface{}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, err
+	}
+	return data, nil
+}

--- a/cmd/csv2parquet/main_test.go
+++ b/cmd/csv2parquet/main_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTypeHints(t *testing.T) {
+	tests := map[string]struct {
+		Input          string
+		ExpectedOutput map[string]string
+		ExpectErr      bool
+	}{
+		"simple": {
+			Input:          "foo=boolean,bar=string",
+			ExpectedOutput: map[string]string{"foo": "boolean", "bar": "string"},
+		},
+		"simply-with-spaces": {
+			Input: "   foo  =  boolean ,	bar=string	 ",
+			ExpectedOutput: map[string]string{"foo": "boolean", "bar": "string"},
+		},
+		"empty": {
+			Input:          "",
+			ExpectedOutput: map[string]string{},
+		},
+		"invalid-type": {
+			Input:     "foo=invalid-type",
+			ExpectErr: true,
+		},
+		"invalid-field": {
+			Input:     "foo=boolean=invalid",
+			ExpectErr: true,
+		},
+	}
+
+	for testName, tt := range tests {
+		t.Run(testName, func(t *testing.T) {
+			output, err := parseTypeHints(tt.Input)
+			if tt.ExpectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.ExpectedOutput, output)
+			}
+		})
+	}
+}
+
+func TestTypeHandlers(t *testing.T) {
+	tests := map[string]struct {
+		Input          string
+		Func           func(string) (interface{}, error)
+		ExpectedOutput interface{}
+		ExpectErr      bool
+	}{
+		"byte-array":        {"hello", byteArrayHandler, []byte("hello"), false},
+		"boolean-true":      {"true", booleanHandler, true, false},
+		"boolean-false":     {"false", booleanHandler, false, false},
+		"boolean-invalid":   {"invalid", booleanHandler, false, true},
+		"bool-UPPERCASE":    {"TRUE", booleanHandler, true, false},
+		"bool-num-1":        {"1", booleanHandler, true, false},
+		"bool-num-0":        {"0", booleanHandler, false, false},
+		"uint-32":           {"1234", uintHandler(32), uint32(1234), false},
+		"uint-invalid":      {"hello!", uintHandler(32), 0, true},
+		"uint-invalid-bits": {"1234", uintHandler(28), 0, true},
+		"uint-64":           {"1000000000000", uintHandler(64), uint64(1000000000000), false},
+		"int-32":            {"-1234", intHandler(32), int32(-1234), false},
+		"int-invalid":       {"goodbye!", intHandler(32), 0, true},
+		"int-invalid-bits":  {"1234", intHandler(42), 0, true},
+		"int-64":            {"1000000000000", intHandler(64), int64(1000000000000), false},
+		"float":             {"3.4", floatHandler, float32(3.4), false},
+		"double":            {"4.2", doubleHandler, float64(4.2), false},
+		"json-simple":       {`{"hello":"world"}`, jsonHandler, []byte(`{"hello":"world"}`), false},
+		"json-invalid":      {`{"hello":"world`, jsonHandler, nil, true},
+	}
+
+	for testName, tt := range tests {
+		t.Run(testName, func(t *testing.T) {
+			output, err := tt.Func(tt.Input)
+			if tt.ExpectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.ExpectedOutput, output)
+			}
+		})
+	}
+}

--- a/cmd/csv2parquet/main_test.go
+++ b/cmd/csv2parquet/main_test.go
@@ -293,6 +293,17 @@ func TestWriteParquetData(t *testing.T) {
 				{"invalid value"},
 			},
 		},
+		"null-value-in-record": {
+			Header: []string{"foo", "bar"},
+			Types:  map[string]string{"foo": "int64", "bar": "string"},
+			Records: [][]string{
+				{"", "hello world"},
+			},
+			ExpectedSchema: "message msg {\n  optional int64 foo (INT(64, true));\n  optional binary bar (STRING);\n}\n",
+			ExpectedRows: []map[string]interface{}{
+				{"bar": []byte("hello world")},
+			},
+		},
 	}
 
 	for testName, tt := range tests {

--- a/cmd/csv2parquet/main_test.go
+++ b/cmd/csv2parquet/main_test.go
@@ -345,5 +345,4 @@ func TestWriteParquetData(t *testing.T) {
 			require.Equal(t, tt.ExpectedRows, rows)
 		})
 	}
-
 }

--- a/compress.go
+++ b/compress.go
@@ -134,6 +134,21 @@ func RegisterBlockCompressor(method parquet.CompressionCodec, compressor BlockCo
 	compressors[method] = compressor
 }
 
+// GetRegisteredBlockCompressors returns a map of compression codecs to block compressors that
+// are currently registered.
+func GetRegisteredBlockCompressors() map[parquet.CompressionCodec]BlockCompressor {
+	result := make(map[parquet.CompressionCodec]BlockCompressor)
+
+	compressorLock.Lock()
+	defer compressorLock.Unlock()
+
+	for k, v := range compressors {
+		result[k] = v
+	}
+
+	return result
+}
+
 func init() {
 	RegisterBlockCompressor(parquet.CompressionCodec_UNCOMPRESSED, plainCompressor{})
 	RegisterBlockCompressor(parquet.CompressionCodec_GZIP, gzipCompressor{})


### PR DESCRIPTION
This PR adds a new tool csv2parquet that allows the conversion of existing CSV files to parquet files. The generated schema is derived from the CSV file's header but the column types can be influenced with type hints.