### PR TITLE
stop panic on nil value

### DIFF
--- a/type_bytearray.go
+++ b/type_bytearray.go
@@ -382,5 +382,9 @@ func (*byteArrayStore) append(arrayIn interface{}, value interface{}) interface{
 	if arrayIn == nil {
 		arrayIn = make([][]byte, 0, 1)
 	}
+	if value == nil {
+		return append(arrayIn.([][]byte), nil)
+	}
+
 	return append(arrayIn.([][]byte), value.([]byte))
 }


### PR DESCRIPTION
We have files that we are processing that have nil values inside of a list somewhere, that when casted via
````
 value.([]byte)
````
Causes a panic.

This change will instead append the nil value and seems to fix our problem.  I am not privy to whether or not this is allowed in parquet, or a good suggested change for the lib.