### PR TITLE
floor: add backwards compatibility for Athena-style lists

### DIFF
--- a/floor/interfaces/unmarshaller_test.go
+++ b/floor/interfaces/unmarshaller_test.go
@@ -237,7 +237,7 @@ func TestObjectUnmarshallingErrors(t *testing.T) {
 
 func TestObjectUnmarshallingList(t *testing.T) {
 	testData := map[string]map[string]interface{}{
-		"new-style-list": map[string]interface{}{
+		"new-style-list": {
 			"emails": map[string]interface{}{
 				"list": []map[string]interface{}{
 					{
@@ -249,7 +249,7 @@ func TestObjectUnmarshallingList(t *testing.T) {
 				},
 			},
 		},
-		"athena-compat": map[string]interface{}{
+		"athena-compat": {
 			"emails": map[string]interface{}{
 				"bag": []map[string]interface{}{
 					{

--- a/floor/interfaces/unmarshaller_test.go
+++ b/floor/interfaces/unmarshaller_test.go
@@ -234,3 +234,59 @@ func TestObjectUnmarshallingErrors(t *testing.T) {
 	_, err = dataMap.Value()
 	require.Error(t, err)
 }
+
+func TestObjectUnmarshallingList(t *testing.T) {
+	testData := map[string]map[string]interface{}{
+		"new-style-list": map[string]interface{}{
+			"emails": map[string]interface{}{
+				"list": []map[string]interface{}{
+					{
+						"element": []byte("foo@example.com"),
+					},
+					{
+						"element": []byte("bar@example.com"),
+					},
+				},
+			},
+		},
+		"athena-compat": map[string]interface{}{
+			"emails": map[string]interface{}{
+				"bag": []map[string]interface{}{
+					{
+						"array_element": []byte("foo@example.com"),
+					},
+					{
+						"array_element": []byte("bar@example.com"),
+					},
+				},
+			},
+		},
+	}
+
+	for testName, input := range testData {
+		t.Run(testName, func(t *testing.T) {
+			obj := NewUnmarshallObject(input)
+
+			emailList, err := obj.GetField("emails").List()
+			require.NoError(t, err)
+
+			require.True(t, emailList.Next())
+
+			v, err := emailList.Value()
+			require.NoError(t, err)
+			v1, err := v.ByteArray()
+			require.NoError(t, err)
+			require.Equal(t, "foo@example.com", string(v1))
+
+			require.True(t, emailList.Next())
+
+			v, err = emailList.Value()
+			require.NoError(t, err)
+			v2, err := v.ByteArray()
+			require.NoError(t, err)
+			require.Equal(t, "bar@example.com", string(v2))
+
+			require.False(t, emailList.Next())
+		})
+	}
+}

--- a/floor/reader.go
+++ b/floor/reader.go
@@ -83,7 +83,7 @@ func (r *Reader) Next() bool {
 // Unmarshaller interface.
 func (r *Reader) Scan(obj interface{}) error {
 	if r.data == nil {
-		return errors.New("Scan called before Next")
+		return errors.New("the Next function needs to be called before Scan can be called")
 	}
 	um, ok := obj.(interfaces.Unmarshaller)
 	if !ok {

--- a/parquetschema/schema_def.go
+++ b/parquetschema/schema_def.go
@@ -127,6 +127,10 @@ func (sd *SchemaDefinition) String() string {
 // that matches the provided name. If no such child exists, nil is
 // returned.
 func (sd *SchemaDefinition) SubSchema(name string) *SchemaDefinition {
+	if sd == nil {
+		return nil
+	}
+
 	for _, c := range sd.RootColumn.Children {
 		if c.SchemaElement.Name == name {
 			return &SchemaDefinition{


### PR DESCRIPTION
This PR adds backwards compatibility for Athena-style lists to floor. What I call "Athena-style lists" are lists that are structured as `.bag.array_element` instead `.list.element` as outlined in https://github.com/apache/parquet-format/blob/master/LogicalTypes.md.

This is necessary to read lists that were produced by Athena, e.g. through a CTAS query. In that case, Athena rewrites the schema so that a list previously structured as `.list.element` in the original data is now structured as `.bag.array_element` in the output data. This backwards compatibility shall ensure that even when the structure changes like this, objects that implement their own `MarshalParquet` and `UnmarshalParquet` methods for floor can read data despite the slightly changed schema.