### PR TITLE
Add code examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added examples how to use the low-level and high-level APIs.
 - Added backwards compability in floor reader and writer for lists as produced by Athena.
 - Fixed many crash issues found during fuzzing of the parquet reader.
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ it follows some conventions. In particular, it has to contain only a single
 fields, one named `key`, the other named `value`. This represents a map
 structure in which each key is associated with one value.
 
+## Examples
+
+For examples how to use both the low-level and high-level APIs of this library, please
+see the directory `examples`. You can also check out the accompanying tools (see below)
+for more advanced examples. The tools are located in the `cmd` directory.
+
 ## Tools
 
 `parquet-go` comes with tooling to inspect and generate parquet tools.

--- a/examples/high-level-custom-marshalling/main.go
+++ b/examples/high-level-custom-marshalling/main.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"log"
+	"reflect"
+
+	goparquet "github.com/fraugster/parquet-go"
+	"github.com/fraugster/parquet-go/floor"
+	"github.com/fraugster/parquet-go/floor/interfaces"
+	"github.com/fraugster/parquet-go/parquet"
+	"github.com/fraugster/parquet-go/parquetschema"
+)
+
+func main() {
+	schemaDef, err := parquetschema.ParseSchemaDefinition(
+		`message test {
+			required binary name (STRING);
+			required binary data;
+			required double score;
+		}`)
+	if err != nil {
+		log.Fatalf("Parsing schema definition failed: %v", err)
+	}
+
+	parquetFilename := "output.parquet"
+
+	fw, err := floor.NewFileWriter(parquetFilename,
+		goparquet.WithSchemaDefinition(schemaDef),
+		goparquet.WithCompressionCodec(parquet.CompressionCodec_SNAPPY),
+	)
+	if err != nil {
+		log.Fatalf("Opening parquet file for writing failed: %v", err)
+	}
+
+	input := []*record{
+		{
+			n: "Test",
+			d: []byte{0xFF, 0x0A, 0x8E, 0x00, 0x12},
+			s: 23.5,
+		},
+	}
+
+	for _, rec := range input {
+		if err := fw.Write(rec); err != nil {
+			log.Fatalf("Writing record failed: %v", err)
+		}
+	}
+
+	if err := fw.Close(); err != nil {
+		log.Fatalf("Closing parquet writer failed: %v", err)
+	}
+
+	fr, err := floor.NewFileReader(parquetFilename)
+	if err != nil {
+		log.Fatalf("Opening parquet file failed: %v", err)
+	}
+
+	var fileContent []*record
+
+	for fr.Next() {
+		rec := &record{}
+		if err := fr.Scan(rec); err != nil {
+			log.Fatalf("Scanning record failed: %v", err)
+		}
+		fileContent = append(fileContent, rec)
+	}
+
+	equal := reflect.DeepEqual(input, fileContent)
+	if equal {
+		log.Printf("Congratulations! The input and the data read back are identical!")
+	} else {
+		log.Printf("This is strange... the data read back does not back what has been written to the file.")
+	}
+}
+
+type record struct {
+	n string
+	d []byte
+	s float64
+}
+
+func (r *record) MarshalParquet(obj interfaces.MarshalObject) error {
+	obj.AddField("name").SetByteArray([]byte(r.n))
+	obj.AddField("data").SetByteArray(r.d)
+	obj.AddField("score").SetFloat64(r.s)
+	return nil
+}
+
+func (r *record) UnmarshalParquet(obj interfaces.UnmarshalObject) error {
+	name, err := obj.GetField("name").ByteArray()
+	if err != nil {
+		return nil
+	}
+	r.n = string(name)
+
+	data, err := obj.GetField("data").ByteArray()
+	if err != nil {
+		return nil
+	}
+	r.d = data
+
+	score, err := obj.GetField("score").Float64()
+	if err != nil {
+		return nil
+	}
+	r.s = score
+
+	return nil
+}

--- a/examples/high-level-reflection/main.go
+++ b/examples/high-level-reflection/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"log"
+	"reflect"
+
+	goparquet "github.com/fraugster/parquet-go"
+	"github.com/fraugster/parquet-go/floor"
+	"github.com/fraugster/parquet-go/parquet"
+	"github.com/fraugster/parquet-go/parquetschema"
+)
+
+func main() {
+	schemaDef, err := parquetschema.ParseSchemaDefinition(
+		`message test {
+			required binary name (STRING);
+			required binary data;
+			required double score;
+		}`)
+	if err != nil {
+		log.Fatalf("Parsing schema definition failed: %v", err)
+	}
+
+	parquetFilename := "output.parquet"
+
+	fw, err := floor.NewFileWriter(parquetFilename,
+		goparquet.WithSchemaDefinition(schemaDef),
+		goparquet.WithCompressionCodec(parquet.CompressionCodec_SNAPPY),
+	)
+	if err != nil {
+		log.Fatalf("Opening parquet file for writing failed: %v", err)
+	}
+
+	type record struct {
+		Name  string  `parquet:"name"`
+		Data  []byte  `parquet:"data"`
+		Score float64 `parquet:"score"`
+	}
+
+	input := []record{
+		{
+			Name:  "Test",
+			Data:  []byte{0xFF, 0x0A, 0x8E, 0x00, 0x12},
+			Score: 23.5,
+		},
+	}
+
+	for _, rec := range input {
+		if err := fw.Write(rec); err != nil {
+			log.Fatalf("Writing record failed: %v", err)
+		}
+	}
+
+	if err := fw.Close(); err != nil {
+		log.Fatalf("Closing parquet writer failed: %v", err)
+	}
+
+	fr, err := floor.NewFileReader(parquetFilename)
+	if err != nil {
+		log.Fatalf("Opening parquet file failed: %v", err)
+	}
+
+	var fileContent []record
+
+	for fr.Next() {
+		var rec record
+		if err := fr.Scan(&rec); err != nil {
+			log.Fatalf("Scanning record failed: %v", err)
+		}
+		fileContent = append(fileContent, rec)
+	}
+
+	equal := reflect.DeepEqual(input, fileContent)
+	if equal {
+		log.Printf("Congratulations! The input and the data read back are identical!")
+	} else {
+		log.Printf("This is strange... the data read back does not back what has been written to the file.")
+	}
+}

--- a/examples/read-low-level/main.go
+++ b/examples/read-low-level/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	goparquet "github.com/fraugster/parquet-go"
+)
+
+func main() {
+	flag.Parse()
+
+	if len(flag.Args()) == 0 {
+		log.Fatalf("Usage: %s <parquet-file>...", os.Args[0])
+	}
+
+	for _, file := range flag.Args() {
+		if err := printFile(file); err != nil {
+			log.Printf("Failed to print file %s: %v", file, err)
+		}
+	}
+}
+
+func printFile(file string) error {
+	r, err := os.Open(file)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	fr, err := goparquet.NewFileReader(r)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("Printing file %s", file)
+	log.Printf("Schema: %s", fr.GetSchemaDefinition())
+
+	count := 0
+	for {
+		row, err := fr.NextRow()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading record failed: %w", err)
+		}
+
+		log.Printf("Record %d:", count)
+		for k, v := range row {
+			if vv, ok := v.([]byte); ok {
+				v = string(vv)
+			}
+			log.Printf("\t%s = %v", k, v)
+		}
+
+		count++
+	}
+
+	log.Printf("End of file %s (%d records)", file, count)
+	return nil
+}

--- a/examples/write-low-level/main.go
+++ b/examples/write-low-level/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	goparquet "github.com/fraugster/parquet-go"
+	"github.com/fraugster/parquet-go/parquet"
+	"github.com/fraugster/parquet-go/parquetschema"
+)
+
+func main() {
+	f, err := os.OpenFile("output.parquet", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		log.Fatalf("Opening output file failed: %v", err)
+	}
+	defer f.Close()
+
+	schemaDef, err := parquetschema.ParseSchemaDefinition(
+		`message test {
+			required int64 id;
+			required binary city (STRING);
+			optional int64 population;
+		}`)
+
+	fw := goparquet.NewFileWriter(f,
+		goparquet.WithCompressionCodec(parquet.CompressionCodec_SNAPPY),
+		goparquet.WithSchemaDefinition(schemaDef),
+		goparquet.WithCreator("write-lowlevel"),
+	)
+
+	inputData := []struct {
+		ID   int
+		City string
+		Pop  int
+	}{
+		{ID: 1, City: "Berlin", Pop: 3520031},
+		{ID: 2, City: "Hamburg", Pop: 1787408},
+		{ID: 3, City: "Munich", Pop: 1450381},
+		{ID: 4, City: "Cologne", Pop: 1060582},
+		{ID: 5, City: "Frankfurt", Pop: 732688},
+	}
+
+	for _, input := range inputData {
+		if err := fw.AddData(map[string]interface{}{
+			"id":         int64(input.ID),
+			"city":       []byte(input.City),
+			"population": int64(input.Pop),
+		}); err != nil {
+			log.Fatalf("Failed to add input %v to parquet file: %v", input, err)
+		}
+	}
+
+	if err := fw.Close(); err != nil {
+		log.Fatalf("Closing parquet file writer failed: %v", err)
+	}
+}


### PR DESCRIPTION
This PR adds several examples to demonstrate how to use the low-level and high-level APIs of the parquet-go library.