### PR TITLE
Int96Time - Julian Day -  Add helper function

### DIFF
--- a/cmd/csv2parquet/.gitignore
+++ b/cmd/csv2parquet/.gitignore
@@ -1,0 +1,1 @@
+csv2parquet

--- a/cmd/parquet-tool/.gitignore
+++ b/cmd/parquet-tool/.gitignore
@@ -1,0 +1,1 @@
+parquet-tool

--- a/int96_time.go
+++ b/int96_time.go
@@ -10,6 +10,10 @@ const (
 	secPerDay = 24 * 60 * 60
 )
 
+var (
+	tsUnixEpoch = time.Unix(0, 0)
+)
+
 func timeToJD(t time.Time) (uint32, uint64) {
 	days := t.Unix() / secPerDay
 	nSecs := t.UnixNano() - (days * secPerDay * int64(time.Second))
@@ -43,4 +47,10 @@ func TimeToInt96(t time.Time) [12]byte {
 	binary.LittleEndian.PutUint32(parquetDate[8:], days)
 
 	return parquetDate
+}
+
+// IsAfterUnixEpoch tests if a timestamp can be converted into Julian Day format, i.e. is it greater than 01-01-1970?
+// Timestamps before this when converted will be corrupted when read back.
+func IsAfterUnixEpoch(t time.Time) bool {
+	return t.After(tsUnixEpoch)
 }

--- a/int96_time_test.go
+++ b/int96_time_test.go
@@ -32,3 +32,14 @@ func TestConvert(t *testing.T) {
 	expected := time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC)
 	require.Equal(t, expected, ts.UTC())
 }
+
+func TestTimeAfterUnixEpoch(t *testing.T) {
+	var (
+		t0, t1 time.Time
+	)
+
+	t1, _ = time.Parse(time.RFC3339, "1970-01-01T00:00:01Z")
+
+	require.False(t, IsAfterUnixEpoch(t0))
+	require.True(t, IsAfterUnixEpoch(t1))
+}


### PR DESCRIPTION
Users of parquet go can test if their timestamps can be stored in JD format.