### PR TITLE
Export SetSelectedColumns Outside of Package

### DIFF
--- a/file_reader.go
+++ b/file_reader.go
@@ -35,7 +35,7 @@ func NewFileReader(r io.ReadSeeker, columns ...string) (*FileReader, error) {
 		return nil, errors.Wrap(err, "creating schema failed")
 	}
 
-	schema.setSelectedColumns(columns...)
+	schema.SetSelectedColumns(columns...)
 	// Reset the reader to the beginning of the file
 	if _, err := r.Seek(4, io.SeekStart); err != nil {
 		return nil, err

--- a/schema.go
+++ b/schema.go
@@ -289,7 +289,7 @@ func (r *schema) ensureRoot() {
 	}
 }
 
-func (r *schema) setSelectedColumns(selected ...string) {
+func (r *schema) SetSelectedColumns(selected ...string) {
 	r.selectedColumn = selected
 }
 
@@ -978,7 +978,7 @@ type SchemaReader interface {
 	SchemaCommon
 	setNumRecords(int64)
 	getData() (map[string]interface{}, error)
-	setSelectedColumns(selected ...string)
+	SetSelectedColumns(selected ...string)
 	isSelected(string) bool
 }
 


### PR DESCRIPTION
Many applications need to set the filtering columns at a later stage (not at the creation of the reader). Hence exposing this method would be useful.