### PR TITLE
dictStore: reset valueSize in init()

### DIFF
--- a/type_dict.go
+++ b/type_dict.go
@@ -76,6 +76,7 @@ func (d *dictStore) init() {
 	d.nullCount = 0
 	d.readPos = 0
 	d.size = 0
+	d.valueSize = 0
 }
 
 func (d *dictStore) assemble() []interface{} {

--- a/type_dict_test.go
+++ b/type_dict_test.go
@@ -10,6 +10,7 @@ func TestDictStore(t *testing.T) {
 	d := dictStore{}
 	d.init()
 	require.Equal(t, d.size, int64(0))
+	require.Equal(t, d.valueSize, int64(0))
 
 	d.addValue(int32(1), 4)
 	d.addValue(int32(2), 4)
@@ -20,11 +21,13 @@ func TestDictStore(t *testing.T) {
 	d.addValue(int32(3), 4)
 	d.addValue(int32(4), 4)
 	require.Equal(t, d.size, int64(32))
+	require.Equal(t, d.valueSize, int64(16))
 	d.addValue(nil, 4)
 	require.Equal(t, d.size, int64(32))
 
 	d.init()
 	require.Equal(t, d.size, int64(0))
+	require.Equal(t, d.valueSize, int64(0))
 }
 
 func TestFuzzCrashDictDecoderDecodeValues(t *testing.T) {


### PR DESCRIPTION
And update the tests.

valueSize is only ever used for computing
the `(*ColumnStore).useDictionary()` heuristic, so everything continued
to function fine, but the encoder would almost never choose to use a
dictionary encoding past the first row group.

Fixing this shrinks some files I'm generating by more than half.
