### PR TITLE
fix: DECIMAL's `maxDigits` computation is incorrect

### DIFF
--- a/parquetschema/schema_parser.go
+++ b/parquetschema/schema_parser.go
@@ -912,7 +912,7 @@ func (col *ColumnDefinition) validateDecimalLogicalType() error {
 		}
 	case parquet.Type_FIXED_LEN_BYTE_ARRAY:
 		n := *col.SchemaElement.TypeLength
-		maxDigits := int32(math.Floor(math.Log10(math.Exp2(8*float64(n)-1)) - 1))
+		maxDigits := int32(math.Floor(math.Log10(math.Exp2(8*float64(n)-1) - 1)))
 		if dec.Precision < 1 || dec.Precision > maxDigits {
 			return fmt.Errorf("field %s is fixed_len_byte_array(%d) and annotated as DECIMAL but precision %d is out of bounds; needs to be 1 <= precision <= %d", col.SchemaElement.Name, n, dec.Precision, maxDigits)
 		}

--- a/parquetschema/schema_parser_test.go
+++ b/parquetschema/schema_parser_test.go
@@ -301,8 +301,8 @@ func TestSchemaParser(t *testing.T) {
 		}`, false, false},
 		// 70.
 		{`message foo {
-			required fixed_len_byte_array(10) foo (DECIMAL(23,10));
-		}`, true, false}, // 23 is out of bounds; maximum for 10 is 22.
+			required fixed_len_byte_array(10) foo (DECIMAL(24,10));
+		}`, true, false}, // 24 is out of bounds; maximum for 10 is 23.
 		{`message foo {
 			required binary foo (DECIMAL(100,10));
 		}`, false, false},


### PR DESCRIPTION
This is a fix for #36. A test needed to be updated as well.