### PR TITLE
Relax field name parsing

### DIFF
--- a/parquetschema/schema_parser.go
+++ b/parquetschema/schema_parser.go
@@ -228,8 +228,8 @@ func isAlpha(r rune) bool {
 	return r == '_' || unicode.IsLetter(r)
 }
 
-func isAlphaNum(r rune) bool {
-	return isAlpha(r) || isDigit(r)
+func isSchemaDelim(r rune) bool {
+	return r == ' ' || r == ';' || r == '{' || r == '}' || r == '(' || r == ')' || r == '=' || r == ','
 }
 
 func lexSpace(l *schemaLexer) stateFn {
@@ -250,7 +250,7 @@ func lexIdentifier(l *schemaLexer) stateFn {
 loop:
 	for {
 		switch r := l.next(); {
-		case isAlphaNum(r): // the = is there to accept it as part of the identifiers being read within type annotations.
+		case !isSchemaDelim(r): // the = is there to accept it as part of the identifiers being read within type annotations.
 			// absorb.
 		default:
 			l.backup()

--- a/parquetschema/schema_parser_test.go
+++ b/parquetschema/schema_parser_test.go
@@ -486,6 +486,8 @@ message foo { }`, false, false}, // this is necessary because we once had a pars
 
 			}
 		}`, false, true}, // invalid ConvertedType
+		// 110.
+		{`message foo { required binary METADATA$ACTION (STRING); }`, false, false}, // column name includes special character.
 	}
 
 	for idx, tt := range testData {


### PR DESCRIPTION
I tried this library with some test data unloaded from Snowflake. When Snowflake unloads a stream as Parquet, it includes additional fields `METADATA$ACTION`, `METADATA$ISUPDATE`, and `METADATA$ROW_ID`. The CLI tool [pqrs][pqrs], built on [the official Parquet library for Rust][parquet], has no problem handling these:

```
$ pqrs schema ~/Downloads/data_0_0_0.snappy.parquet
Metadata for file: /Users/mark/Downloads/data_0_0_0.snappy.parquet

version: 1
num of rows: 8370912
created by: parquet-cpp version 1.5.1-SNAPSHOT
message schema {
  REQUIRED FIXED_LEN_BYTE_ARRAY (16) S_SUPPKEY (DECIMAL(38,0));
  REQUIRED BYTE_ARRAY S_NAME (STRING);
  REQUIRED BYTE_ARRAY S_ADDRESS (STRING);
  REQUIRED FIXED_LEN_BYTE_ARRAY (16) S_NATIONKEY (DECIMAL(38,0));
  REQUIRED BYTE_ARRAY S_PHONE (STRING);
  REQUIRED FIXED_LEN_BYTE_ARRAY (8) S_ACCTBAL (DECIMAL(12,2));
  OPTIONAL BYTE_ARRAY S_COMMENT (STRING);
  REQUIRED BYTE_ARRAY METADATA$ACTION (STRING);
  OPTIONAL BOOLEAN METADATA$ISUPDATE;
  OPTIONAL BYTE_ARRAY METADATA$ROW_ID (STRING);
}
```

And, if the metadata is to be trusted, apparently [parquet-cpp][parquet-cpp] can deal with such columns, too. But I hit a problem when using this library, similar to #25.

To address it, I changed the `lexIdentifier` function to behave more like the Rust implementation: rather than assert each character of the identifier is alphanumeric (plus underscore), I instead assert each character is not a "schema delimiter". This is what the tokenizer in the Rust implementation does (see [here][example]). I also added a test.

[pqrs]: https://github.com/manojkarthick/pqrs
[parquet]: https://github.com/apache/arrow-rs
[parquet-cpp]: https://github.com/apache/parquet-cpp
[example]: https://github.com/apache/arrow-rs/blob/8308615d40e14caa5cdbee118ecc2f46696b920f/parquet/src/schema/parser.rs#L75-L117