### PR TITLE
feat: allow reading FileMetaData beforehand

### DIFF
--- a/file_meta.go
+++ b/file_meta.go
@@ -11,30 +11,32 @@ import (
 
 var magic = []byte{'P', 'A', 'R', '1'}
 
-func readFileMetaData(r io.ReadSeeker) (*parquet.FileMetaData, error) {
-	if _, err := r.Seek(0, io.SeekStart); err != nil {
-		return nil, errors.Wrap(err, "seek for the file magic header failed")
-	}
+func ReadFileMetaData(r io.ReadSeeker, extraValidation bool) (*parquet.FileMetaData, error) {
+	if extraValidation {
+		if _, err := r.Seek(0, io.SeekStart); err != nil {
+			return nil, errors.Wrap(err, "seek for the file magic header failed")
+		}
 
-	buf := make([]byte, 4)
-	// read and validate header
-	if _, err := io.ReadFull(r, buf); err != nil {
-		return nil, errors.Wrap(err, "read the file magic header failed")
-	}
-	if !bytes.Equal(buf, magic) {
-		return nil, errors.Errorf("invalid parquet file header")
-	}
+		buf := make([]byte, 4)
+		// read and validate header
+		if _, err := io.ReadFull(r, buf); err != nil {
+			return nil, errors.Wrap(err, "read the file magic header failed")
+		}
+		if !bytes.Equal(buf, magic) {
+			return nil, errors.Errorf("invalid parquet file header")
+		}
 
-	// read and validate footer
-	if _, err := r.Seek(-4, io.SeekEnd); err != nil {
-		return nil, errors.Wrap(err, "seek for the file magic footer failed")
-	}
+		// read and validate footer
+		if _, err := r.Seek(-4, io.SeekEnd); err != nil {
+			return nil, errors.Wrap(err, "seek for the file magic footer failed")
+		}
 
-	if _, err := io.ReadFull(r, buf); err != nil {
-		return nil, errors.Wrap(err, "read the file magic header failed")
-	}
-	if !bytes.Equal(buf, magic) {
-		return nil, errors.Errorf("invalid parquet file footer")
+		if _, err := io.ReadFull(r, buf); err != nil {
+			return nil, errors.Wrap(err, "read the file magic header failed")
+		}
+		if !bytes.Equal(buf, magic) {
+			return nil, errors.Errorf("invalid parquet file footer")
+		}
 	}
 
 	// read footer length


### PR DESCRIPTION
I have an application where I want to read a Parquet file's metadata and then spawn a goroutine for each row group contained within. To do this, I first read the Parquet file's metadata before actually constructing a FileReader.

Also, I sometimes read files from S3 using range requests (for example, my [project here](https://github.com/markandrus/s3readerat)). In these cases, I generally trust the files in S3 and want to minimize seeking (and therefore range requests). So I've also added a boolean, `extraValidation`, which enables or disables seeking to the start of the file to read magic bytes.