### PR TITLE
feat: allowing seeking to specific Row Groups

### DIFF
--- a/file_reader.go
+++ b/file_reader.go
@@ -47,6 +47,12 @@ func NewFileReader(r io.ReadSeeker, columns ...string) (*FileReader, error) {
 	}, nil
 }
 
+func (f *FileReader) SeekToRowGroup(rowGroupPosition int) error {
+	f.rowGroupPosition = rowGroupPosition - 1
+	f.currentRecord = 0
+	return f.readRowGroup()
+}
+
 // readRowGroup read the next row group into memory
 func (f *FileReader) readRowGroup() error {
 	if len(f.meta.RowGroups) <= f.rowGroupPosition {


### PR DESCRIPTION
In my application, I often spawn a goroutine per Row Group, and so its useful to be able to seek directly to the Row Group.