### PR TITLE
Fix Reading & Writing of INT96 time

### DIFF
--- a/floor/reader.go
+++ b/floor/reader.go
@@ -345,7 +345,12 @@ func (um *reflectUnmarshaller) fillMap(value reflect.Value, data interfaces.Unma
 func (um *reflectUnmarshaller) fillByteArrayOrSlice(value reflect.Value, data interfaces.UnmarshalElement, schemaDef *parquetschema.SchemaDefinition) error {
 	byteSlice, err := data.ByteArray()
 	if err != nil {
-		return err
+		// check to see if it's actually an INT96
+		int96, int96Err := data.Int96()
+		if int96Err != nil {
+			return err
+		}
+		byteSlice = int96[0:]
 	}
 	if value.Kind() == reflect.Slice {
 		value.Set(reflect.MakeSlice(value.Type(), len(byteSlice), len(byteSlice)))

--- a/floor/reader.go
+++ b/floor/reader.go
@@ -235,6 +235,14 @@ func (um *reflectUnmarshaller) fillValue(value reflect.Value, data interfaces.Un
 			case elem.GetLogicalType().IsSetTIMESTAMP():
 				return um.fillTimestampValue(elem, value, data)
 			}
+		} else if elem.GetType() == parquet.Type_INT96 {
+			i96, err := data.Int96()
+			if err != nil {
+				return err
+			}
+
+			value.Set(reflect.ValueOf(goparquet.Int96ToTime(i96).UTC()))
+			return nil
 		}
 	}
 

--- a/floor/reader_test.go
+++ b/floor/reader_test.go
@@ -6,14 +6,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fraugster/parquet-go/floor/interfaces"
 	"github.com/pkg/errors"
 
+	"github.com/fraugster/parquet-go/floor/interfaces"
+
 	"github.com/davecgh/go-spew/spew"
+	"github.com/stretchr/testify/require"
+
 	goparquet "github.com/fraugster/parquet-go"
 	"github.com/fraugster/parquet-go/parquet"
 	"github.com/fraugster/parquet-go/parquetschema"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNewReaderFailures(t *testing.T) {
@@ -525,6 +527,7 @@ func TestFillValue(t *testing.T) {
 		required int64 tsnano (TIMESTAMP(NANOS, true));
 		required int64 tsmicro (TIMESTAMP(MICROS, true));
 		required int64 tsmilli (TIMESTAMP(MILLIS, true));
+		required int96 tshive;
 		required int64 tnano (TIME(NANOS, true));
 		required int64 tmicro (TIME(MICROS, true));
 		required int32 tmilli (TIME(MILLIS, true));
@@ -544,6 +547,9 @@ func TestFillValue(t *testing.T) {
 
 	require.NoError(t, um.fillValue(reflect.ValueOf(&ts).Elem(), elem(int64(45299450)), sd.SubSchema("tsmilli")))
 	require.Equal(t, ts, time.Date(1970, 1, 1, 12, 34, 59, 450000000, time.UTC))
+
+	require.NoError(t, um.fillValue(reflect.ValueOf(&ts).Elem(), elem([12]byte{00, 0x60, 0xFD, 0x4B, 0x32, 0x29, 0x00, 0x00, 0x59, 0x68, 0x25, 0x00}), sd.SubSchema("tshive")))
+	require.Equal(t, ts, time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC))
 
 	var tt Time
 	require.NoError(t, um.fillValue(reflect.ValueOf(&tt).Elem(), elem(int64(30000000010)), sd.SubSchema("tnano")))

--- a/floor/writer.go
+++ b/floor/writer.go
@@ -172,7 +172,7 @@ func (m *reflectMarshaller) decodeValue(field interfaces.MarshalElement, value r
 			case elem.GetLogicalType().IsSetTIMESTAMP():
 				return m.decodeTimestampValue(elem, field, value)
 			}
-		} else if *elem.Type == parquet.Type_INT96 {
+		} else if elem.GetType() == parquet.Type_INT96 {
 			field.SetInt96(goparquet.TimeToInt96(value.Interface().(time.Time)))
 			return nil
 		}
@@ -232,7 +232,7 @@ func (m *reflectMarshaller) decodeByteSliceOrArray(field interfaces.MarshalEleme
 		}
 		field.SetByteArray(value.Bytes())
 	case reflect.Array:
-		if *elem.Type == parquet.Type_INT96 {
+		if elem.GetType() == parquet.Type_INT96 {
 			if value.Len() != 12 {
 				return fmt.Errorf("field is of type INT96 but length is %d", value.Len())
 			}


### PR DESCRIPTION
## Issue(s)

1. The Parquet Reflect Unmarshaller was treating Arrays, specifically `[12]byte` which the Int96Type uses, and setting as `[]byte` which is not the same thing and so getting INT96 values fail.
2. `time.Time` conversion to `INT96` was not supported.
3. Reading `INT96` to `time.Time` did not work.
4. Reading into `[12]byte` for `INT96` failed.

## PR
This PR makes fixes to support the `INT96` type and conversions I the Reflect Marshaller and Unmarshaller.

**NOTE:** This PR also used #35 to solve `INT96` => `time.Time` conversion