### PR TITLE
Add autoschema package to automatically generate schemas using reflection

### DIFF
--- a/floor/writer_test.go
+++ b/floor/writer_test.go
@@ -1,7 +1,6 @@
 package floor
 
 import (
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -568,12 +567,12 @@ func (r *marshTestRecord) MarshalParquet(obj interfaces.MarshalObject) error {
 		grp.AddField("quux").SetInt64(b.quux)
 	}
 
-	fmt.Printf("marshal data: %s", spew.Sdump(obj.GetData()))
+	//fmt.Printf("marshal data: %s", spew.Sdump(obj.GetData()))
 	return nil
 }
 
 func (r *marshTestRecord) UnmarshalParquet(obj interfaces.UnmarshalObject) error {
-	fmt.Printf("unmarshal data: %s", spew.Sdump(obj.GetData()))
+	//fmt.Printf("unmarshal data: %s", spew.Sdump(obj.GetData()))
 
 	foo := obj.GetField("foo")
 	if err := foo.Error(); err != nil {

--- a/floor/writer_test.go
+++ b/floor/writer_test.go
@@ -567,13 +567,10 @@ func (r *marshTestRecord) MarshalParquet(obj interfaces.MarshalObject) error {
 		grp.AddField("quux").SetInt64(b.quux)
 	}
 
-	//fmt.Printf("marshal data: %s", spew.Sdump(obj.GetData()))
 	return nil
 }
 
 func (r *marshTestRecord) UnmarshalParquet(obj interfaces.UnmarshalObject) error {
-	//fmt.Printf("unmarshal data: %s", spew.Sdump(obj.GetData()))
-
 	foo := obj.GetField("foo")
 	if err := foo.Error(); err != nil {
 		return err

--- a/floor/writeread_test.go
+++ b/floor/writeread_test.go
@@ -735,6 +735,13 @@ func TestWriteReadWithAutoSchema(t *testing.T) {
 			})
 		})
 
+		t.Run("time.Time", func(t *testing.T) {
+			t.Run("time.Time go type", func(t *testing.T) {
+				o := struct{ Val time.Time }{Val: time.Now().UTC()}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+		})
+
 		t.Run("groups", func(t *testing.T) {
 			t.Run("nested struct go type", func(t *testing.T) {
 				type child struct{ Val int64 }

--- a/floor/writeread_test.go
+++ b/floor/writeread_test.go
@@ -9,6 +9,7 @@ import (
 	goparquet "github.com/fraugster/parquet-go"
 	"github.com/fraugster/parquet-go/parquet"
 	"github.com/fraugster/parquet-go/parquetschema"
+	"github.com/fraugster/parquet-go/parquetschema/autoschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -559,6 +560,198 @@ func TestWriteRead(t *testing.T) {
 				extra map[int]int
 			}{Val: 1, extra: nil}
 			assert.EqualValues(t, e, writeReadOne(t, o, s))
+		})
+	})
+}
+
+func writeReadOneWithAutoSchema(t *testing.T, o interface{}) interface{} {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Error(r)
+		}
+	}()
+	schemaDef, err := autoschema.GenerateSchema(o)
+	require.NoError(t, err)
+	t.Logf("auto-generated schema: %v", schemaDef)
+
+	var buf bytes.Buffer
+	w := NewWriter(goparquet.NewFileWriter(&buf,
+		goparquet.WithCompressionCodec(parquet.CompressionCodec_SNAPPY),
+		goparquet.WithSchemaDefinition(schemaDef),
+	))
+
+	err = w.Write(o)
+	require.NoError(t, err)
+
+	err = w.Close()
+	require.NoError(t, err)
+
+	fr, err := goparquet.NewFileReader(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+
+	pr := NewReader(fr)
+
+	pr.Next()
+
+	o2val := reflect.New(reflect.TypeOf(o))
+	err = pr.Scan(o2val.Interface())
+	require.NoError(t, err)
+
+	return o2val.Elem().Interface()
+}
+
+func TestWriteReadWithAutoSchema(t *testing.T) {
+	t.Run("by parquet type", func(t *testing.T) {
+		t.Run("int64", func(t *testing.T) {
+			t.Run("int go type", func(t *testing.T) {
+				o := struct{ Val int }{Val: 1}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+
+			t.Run("int64 go type", func(t *testing.T) {
+				o := struct{ Val int64 }{Val: 1}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+
+			t.Run("int32 go type", func(t *testing.T) {
+				o := struct{ Val int32 }{Val: 1}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+
+			t.Run("int16 go type", func(t *testing.T) {
+				o := struct{ Val int16 }{Val: 1}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+
+			t.Run("int8 go type", func(t *testing.T) {
+				o := struct{ Val int8 }{Val: 1}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+
+			t.Run("uint go type", func(t *testing.T) {
+				o := struct{ Val uint }{Val: 1}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+
+			t.Run("uint32 go type", func(t *testing.T) {
+				o := struct{ Val uint32 }{Val: 1}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+
+			t.Run("uint16 go type", func(t *testing.T) {
+				o := struct{ Val uint16 }{Val: 1}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+
+			t.Run("uint8 go type", func(t *testing.T) {
+				o := struct{ Val uint8 }{Val: 1}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+		})
+
+		t.Run("int32", func(t *testing.T) {
+			t.Run("int go type", func(t *testing.T) {
+				o := struct{ Val int }{Val: 1}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+
+			t.Run("int64 go type", func(t *testing.T) {
+				o := struct{ Val int64 }{Val: 1}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+
+			t.Run("int32 go type", func(t *testing.T) {
+				o := struct{ Val int32 }{Val: 1}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+
+			t.Run("int16 go type", func(t *testing.T) {
+				o := struct{ Val int16 }{Val: 1}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+
+			t.Run("int8 go type", func(t *testing.T) {
+				o := struct{ Val int8 }{Val: 1}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+
+			t.Run("uint go type", func(t *testing.T) {
+				o := struct{ Val uint }{Val: 1}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+
+			t.Run("uint32 go type", func(t *testing.T) {
+				o := struct{ Val uint32 }{Val: 1}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+
+			t.Run("uint16 go type", func(t *testing.T) {
+				o := struct{ Val uint16 }{Val: 1}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+
+			t.Run("uint8 go type", func(t *testing.T) {
+				o := struct{ Val uint8 }{Val: 1}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+		})
+
+		t.Run("byte_arrays", func(t *testing.T) {
+			t.Run("string go type", func(t *testing.T) {
+				o := struct{ Val string }{Val: "1"}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+
+			t.Run("[]byte go type", func(t *testing.T) {
+				o := struct{ Val []byte }{Val: []byte("1")}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+
+			t.Run("[1]byte go type", func(t *testing.T) {
+				o := struct{ Val [1]byte }{Val: [1]byte{'1'}}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+		})
+
+		t.Run("float", func(t *testing.T) {
+			t.Run("float32 go type", func(t *testing.T) {
+				o := struct{ Val float32 }{Val: 1.1}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+		})
+
+		t.Run("double", func(t *testing.T) {
+			t.Run("float64 go type", func(t *testing.T) {
+				o := struct{ Val float64 }{Val: 1.1}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+		})
+
+		t.Run("boolean", func(t *testing.T) {
+			t.Run("bool go type", func(t *testing.T) {
+				o := struct{ Val bool }{Val: true}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+		})
+
+		t.Run("groups", func(t *testing.T) {
+			t.Run("nested struct go type", func(t *testing.T) {
+				type child struct{ Val int64 }
+				type parent struct{ Child child }
+				o := parent{child{1}}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+
+			t.Run("slice go type", func(t *testing.T) {
+				o := struct{ Val []int64 }{Val: []int64{1}}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
+
+			t.Run("map go type", func(t *testing.T) {
+				o := struct{ Val map[int64]int64 }{Val: map[int64]int64{1: 1}}
+				assert.EqualValues(t, o, writeReadOneWithAutoSchema(t, o))
+			})
 		})
 	})
 }

--- a/parquetschema/autoschema/gen.go
+++ b/parquetschema/autoschema/gen.go
@@ -70,7 +70,7 @@ func generateField(fieldType reflect.Type, fieldName string) (*parquetschema.Col
 	case reflect.Int:
 		return &parquetschema.ColumnDefinition{
 			SchemaElement: &parquet.SchemaElement{
-				Type:           parquet.TypePtr(parquet.Type_INT32),
+				Type:           parquet.TypePtr(parquet.Type_INT64),
 				Name:           fieldName,
 				RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED),
 				ConvertedType:  parquet.ConvertedTypePtr(parquet.ConvertedType_INT_32),

--- a/parquetschema/autoschema/gen.go
+++ b/parquetschema/autoschema/gen.go
@@ -309,12 +309,12 @@ func generateField(fieldType reflect.Type, fieldName string) (*parquetschema.Col
 				},
 			}, nil
 		}
-		sliceType, err := generateField(fieldType.Elem(), "list")
+		elementType, err := generateField(fieldType.Elem(), "element")
 		if err != nil {
 			return nil, err
 		}
-		repType := sliceType.SchemaElement.RepetitionType
-		sliceType.SchemaElement.RepetitionType = parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REPEATED)
+		repType := elementType.SchemaElement.RepetitionType
+		elementType.SchemaElement.RepetitionType = parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED)
 		return &parquetschema.ColumnDefinition{
 			SchemaElement: &parquet.SchemaElement{
 				Name:           fieldName,
@@ -325,7 +325,15 @@ func generateField(fieldType reflect.Type, fieldName string) (*parquetschema.Col
 				},
 			},
 			Children: []*parquetschema.ColumnDefinition{
-				sliceType,
+				{
+					SchemaElement: &parquet.SchemaElement{
+						Name:           "list",
+						RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REPEATED),
+					},
+					Children: []*parquetschema.ColumnDefinition{
+						elementType,
+					},
+				},
 			},
 		}, nil
 	case reflect.String:

--- a/parquetschema/autoschema/gen.go
+++ b/parquetschema/autoschema/gen.go
@@ -1,0 +1,371 @@
+package autoschema
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/fraugster/parquet-go/parquet"
+	"github.com/fraugster/parquet-go/parquetschema"
+)
+
+// GenerateSchema auto-generates a schema definition for a provided object's type
+// using reflection. The generated schema is meant to be compatible with
+// github.com/fraugster/parquet-go/floor's reflection-based marshalling/unmarshalling.
+func GenerateSchema(obj interface{}) (*parquetschema.SchemaDefinition, error) {
+	valueObj := reflect.ValueOf(obj)
+	columns, err := generateSchema(valueObj.Type())
+	if err != nil {
+		return nil, fmt.Errorf("can't generate schema: %w", err)
+	}
+
+	return &parquetschema.SchemaDefinition{
+		RootColumn: &parquetschema.ColumnDefinition{
+			SchemaElement: &parquet.SchemaElement{
+				Name: "autogen_schema",
+			},
+			Children: columns,
+		},
+	}, nil
+}
+
+func generateSchema(objType reflect.Type) ([]*parquetschema.ColumnDefinition, error) {
+	if objType.Kind() == reflect.Ptr {
+		objType = objType.Elem()
+	}
+
+	if objType.Kind() != reflect.Struct {
+		return nil, errors.New("can't generate schema: provided object needs to be of type struct or *struct")
+	}
+
+	columns := []*parquetschema.ColumnDefinition{}
+
+	for i := 0; i < objType.NumField(); i++ {
+		fieldType := objType.Field(i)
+		fieldName := fieldNameToLower(fieldType)
+
+		column, err := generateField(fieldType.Type, fieldName)
+		if err != nil {
+			return nil, err
+		}
+
+		columns = append(columns, column)
+	}
+
+	return columns, nil
+}
+
+func generateField(fieldType reflect.Type, fieldName string) (*parquetschema.ColumnDefinition, error) {
+	switch fieldType.Kind() {
+	case reflect.Bool:
+		return &parquetschema.ColumnDefinition{
+			SchemaElement: &parquet.SchemaElement{
+				Type:           parquet.TypePtr(parquet.Type_BOOLEAN),
+				Name:           fieldName,
+				RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED),
+			},
+		}, nil
+	case reflect.Int:
+		return &parquetschema.ColumnDefinition{
+			SchemaElement: &parquet.SchemaElement{
+				Type:           parquet.TypePtr(parquet.Type_INT32),
+				Name:           fieldName,
+				RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED),
+				ConvertedType:  parquet.ConvertedTypePtr(parquet.ConvertedType_INT_32),
+				LogicalType: &parquet.LogicalType{
+					INTEGER: &parquet.IntType{
+						BitWidth: 32,
+						IsSigned: true,
+					},
+				},
+			},
+		}, nil
+	case reflect.Int8:
+		return &parquetschema.ColumnDefinition{
+			SchemaElement: &parquet.SchemaElement{
+				Type:           parquet.TypePtr(parquet.Type_INT32),
+				Name:           fieldName,
+				RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED),
+				ConvertedType:  parquet.ConvertedTypePtr(parquet.ConvertedType_INT_16),
+				LogicalType: &parquet.LogicalType{
+					INTEGER: &parquet.IntType{
+						BitWidth: 8,
+						IsSigned: true,
+					},
+				},
+			},
+		}, nil
+	case reflect.Int16:
+		return &parquetschema.ColumnDefinition{
+			SchemaElement: &parquet.SchemaElement{
+				Type:           parquet.TypePtr(parquet.Type_INT32),
+				Name:           fieldName,
+				RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED),
+				ConvertedType:  parquet.ConvertedTypePtr(parquet.ConvertedType_INT_16),
+				LogicalType: &parquet.LogicalType{
+					INTEGER: &parquet.IntType{
+						BitWidth: 16,
+						IsSigned: true,
+					},
+				},
+			},
+		}, nil
+	case reflect.Int32:
+		return &parquetschema.ColumnDefinition{
+			SchemaElement: &parquet.SchemaElement{
+				Type:           parquet.TypePtr(parquet.Type_INT32),
+				Name:           fieldName,
+				RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED),
+				ConvertedType:  parquet.ConvertedTypePtr(parquet.ConvertedType_INT_32),
+				LogicalType: &parquet.LogicalType{
+					INTEGER: &parquet.IntType{
+						BitWidth: 32,
+						IsSigned: true,
+					},
+				},
+			},
+		}, nil
+	case reflect.Int64:
+		return &parquetschema.ColumnDefinition{
+			SchemaElement: &parquet.SchemaElement{
+				Type:           parquet.TypePtr(parquet.Type_INT64),
+				Name:           fieldName,
+				RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED),
+				ConvertedType:  parquet.ConvertedTypePtr(parquet.ConvertedType_INT_64),
+				LogicalType: &parquet.LogicalType{
+					INTEGER: &parquet.IntType{
+						BitWidth: 64,
+						IsSigned: true,
+					},
+				},
+			},
+		}, nil
+	case reflect.Uint:
+		return &parquetschema.ColumnDefinition{
+			SchemaElement: &parquet.SchemaElement{
+				Type:           parquet.TypePtr(parquet.Type_INT32),
+				Name:           fieldName,
+				RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED),
+				ConvertedType:  parquet.ConvertedTypePtr(parquet.ConvertedType_UINT_32),
+				LogicalType: &parquet.LogicalType{
+					INTEGER: &parquet.IntType{
+						BitWidth: 32,
+						IsSigned: false,
+					},
+				},
+			},
+		}, nil
+	case reflect.Uint8:
+		return &parquetschema.ColumnDefinition{
+			SchemaElement: &parquet.SchemaElement{
+				Type:           parquet.TypePtr(parquet.Type_INT32),
+				Name:           fieldName,
+				RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED),
+				ConvertedType:  parquet.ConvertedTypePtr(parquet.ConvertedType_UINT_16),
+				LogicalType: &parquet.LogicalType{
+					INTEGER: &parquet.IntType{
+						BitWidth: 8,
+						IsSigned: false,
+					},
+				},
+			},
+		}, nil
+	case reflect.Uint16:
+		return &parquetschema.ColumnDefinition{
+			SchemaElement: &parquet.SchemaElement{
+				Type:           parquet.TypePtr(parquet.Type_INT32),
+				Name:           fieldName,
+				RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED),
+				ConvertedType:  parquet.ConvertedTypePtr(parquet.ConvertedType_UINT_16),
+				LogicalType: &parquet.LogicalType{
+					INTEGER: &parquet.IntType{
+						BitWidth: 16,
+						IsSigned: false,
+					},
+				},
+			},
+		}, nil
+	case reflect.Uint32:
+		return &parquetschema.ColumnDefinition{
+			SchemaElement: &parquet.SchemaElement{
+				Type:           parquet.TypePtr(parquet.Type_INT32),
+				Name:           fieldName,
+				RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED),
+				ConvertedType:  parquet.ConvertedTypePtr(parquet.ConvertedType_UINT_32),
+				LogicalType: &parquet.LogicalType{
+					INTEGER: &parquet.IntType{
+						BitWidth: 32,
+						IsSigned: false,
+					},
+				},
+			},
+		}, nil
+	case reflect.Uint64:
+		return &parquetschema.ColumnDefinition{
+			SchemaElement: &parquet.SchemaElement{
+				Type:           parquet.TypePtr(parquet.Type_INT64),
+				Name:           fieldName,
+				RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED),
+				ConvertedType:  parquet.ConvertedTypePtr(parquet.ConvertedType_UINT_64),
+				LogicalType: &parquet.LogicalType{
+					INTEGER: &parquet.IntType{
+						BitWidth: 64,
+						IsSigned: false,
+					},
+				},
+			},
+		}, nil
+	case reflect.Uintptr:
+		return nil, errors.New("unsupported type uintptr")
+	case reflect.Float32:
+		return &parquetschema.ColumnDefinition{
+			SchemaElement: &parquet.SchemaElement{
+				Type:           parquet.TypePtr(parquet.Type_FLOAT),
+				Name:           fieldName,
+				RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED),
+			},
+		}, nil
+	case reflect.Float64:
+		return &parquetschema.ColumnDefinition{
+			SchemaElement: &parquet.SchemaElement{
+				Type:           parquet.TypePtr(parquet.Type_DOUBLE),
+				Name:           fieldName,
+				RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED),
+			},
+		}, nil
+	case reflect.Complex64:
+		return nil, errors.New("unsupported type complex64")
+	case reflect.Complex128:
+		return nil, errors.New("unsupported type complex128")
+	case reflect.Array:
+		if fieldType.Elem().Kind() == reflect.Uint8 {
+			typeLen := int32(fieldType.Len())
+			// handle special case for [N]byte
+			return &parquetschema.ColumnDefinition{
+				SchemaElement: &parquet.SchemaElement{
+					Type:           parquet.TypePtr(parquet.Type_FIXED_LEN_BYTE_ARRAY),
+					Name:           fieldName,
+					RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED),
+					TypeLength:     &typeLen,
+				},
+			}, nil
+		}
+		// TODO: implement this
+		return nil, errors.New("unsupported type array")
+	case reflect.Chan:
+		return nil, errors.New("unsupported type chan")
+	case reflect.Func:
+		return nil, errors.New("unsupported type func")
+	case reflect.Interface:
+		return nil, errors.New("unsupported type interface")
+	case reflect.Map:
+		keyType, err := generateField(fieldType.Key(), "key")
+		if err != nil {
+			return nil, err
+		}
+		valueType, err := generateField(fieldType.Elem(), "value")
+		if err != nil {
+			return nil, err
+		}
+		return &parquetschema.ColumnDefinition{
+			SchemaElement: &parquet.SchemaElement{
+				Name:           fieldName,
+				RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_OPTIONAL),
+				ConvertedType:  parquet.ConvertedTypePtr(parquet.ConvertedType_MAP),
+				LogicalType: &parquet.LogicalType{
+					MAP: &parquet.MapType{},
+				},
+			},
+			Children: []*parquetschema.ColumnDefinition{
+				{
+					SchemaElement: &parquet.SchemaElement{
+						Name:           "key_value",
+						RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REPEATED),
+						ConvertedType:  parquet.ConvertedTypePtr(parquet.ConvertedType_MAP_KEY_VALUE),
+					},
+					Children: []*parquetschema.ColumnDefinition{
+						keyType,
+						valueType,
+					},
+				},
+			},
+		}, nil
+	case reflect.Ptr:
+		colDef, err := generateField(fieldType.Elem(), fieldName)
+		if err != nil {
+			return nil, err
+		}
+		colDef.SchemaElement.RepetitionType = parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_OPTIONAL)
+		return colDef, nil
+	case reflect.Slice:
+		if fieldType.Elem().Kind() == reflect.Uint8 {
+			// handle special case for []byte
+			return &parquetschema.ColumnDefinition{
+				SchemaElement: &parquet.SchemaElement{
+					Type:           parquet.TypePtr(parquet.Type_BYTE_ARRAY),
+					Name:           fieldName,
+					RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED),
+				},
+			}, nil
+		}
+		sliceType, err := generateField(fieldType.Elem(), "list")
+		if err != nil {
+			return nil, err
+		}
+		repType := sliceType.SchemaElement.RepetitionType
+		sliceType.SchemaElement.RepetitionType = parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REPEATED)
+		return &parquetschema.ColumnDefinition{
+			SchemaElement: &parquet.SchemaElement{
+				Name:           fieldName,
+				RepetitionType: repType,
+				ConvertedType:  parquet.ConvertedTypePtr(parquet.ConvertedType_LIST),
+				LogicalType: &parquet.LogicalType{
+					LIST: &parquet.ListType{},
+				},
+			},
+			Children: []*parquetschema.ColumnDefinition{
+				sliceType,
+			},
+		}, nil
+	case reflect.String:
+		return &parquetschema.ColumnDefinition{
+			SchemaElement: &parquet.SchemaElement{
+				Type:           parquet.TypePtr(parquet.Type_BYTE_ARRAY),
+				Name:           fieldName,
+				RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED),
+				ConvertedType:  parquet.ConvertedTypePtr(parquet.ConvertedType_UTF8),
+				LogicalType: &parquet.LogicalType{
+					STRING: &parquet.StringType{},
+				},
+			},
+		}, nil
+	case reflect.Struct:
+		children, err := generateSchema(fieldType)
+		if err != nil {
+			return nil, err
+		}
+		return &parquetschema.ColumnDefinition{
+			SchemaElement: &parquet.SchemaElement{
+				Name:           fieldName,
+				RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED),
+			},
+			Children: children,
+		}, nil
+	case reflect.UnsafePointer:
+		return nil, errors.New("unsafe.Pointer is unsupported")
+	default:
+		return nil, fmt.Errorf("unknown kind %s is unsupported", fieldType.Kind())
+	}
+}
+
+func fieldNameToLower(field reflect.StructField) string {
+	parquetStructTag, ok := field.Tag.Lookup("parquet")
+	if !ok {
+		return strings.ToLower(field.Name)
+	}
+
+	parquetStructTagFields := strings.Split(parquetStructTag, ",")
+
+	return strings.TrimSpace(parquetStructTagFields[0])
+}

--- a/parquetschema/autoschema/gen.go
+++ b/parquetschema/autoschema/gen.go
@@ -73,10 +73,10 @@ func generateField(fieldType reflect.Type, fieldName string) (*parquetschema.Col
 				Type:           parquet.TypePtr(parquet.Type_INT64),
 				Name:           fieldName,
 				RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED),
-				ConvertedType:  parquet.ConvertedTypePtr(parquet.ConvertedType_INT_32),
+				ConvertedType:  parquet.ConvertedTypePtr(parquet.ConvertedType_INT_64),
 				LogicalType: &parquet.LogicalType{
 					INTEGER: &parquet.IntType{
-						BitWidth: 32,
+						BitWidth: 64,
 						IsSigned: true,
 					},
 				},

--- a/parquetschema/autoschema/gen_test.go
+++ b/parquetschema/autoschema/gen_test.go
@@ -1,0 +1,200 @@
+package autoschema
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateSchema(t *testing.T) {
+
+	tests := map[string]struct {
+		Input          interface{}
+		ExpectErr      bool
+		ExpectedOutput string
+	}{
+		"simple types": {
+			Input: struct {
+				Foo  int
+				Bar  uint
+				Baz  string
+				Quux float32
+				Bla  float64
+				Abc  int8
+				Def  int16
+				Ghi  int32
+				Jkl  int64
+				Mno  uint8
+				Pqr  uint16
+				Stu  uint32
+				Vwx  uint64
+				Yz   bool
+			}{},
+			ExpectErr:      false,
+			ExpectedOutput: "message autogen_schema {\n  required int32 foo (INT(32, true));\n  required int32 bar (INT(32, false));\n  required binary baz (STRING);\n  required float quux;\n  required double bla;\n  required int32 abc (INT(8, true));\n  required int32 def (INT(16, true));\n  required int32 ghi (INT(32, true));\n  required int64 jkl (INT(64, true));\n  required int32 mno (INT(8, false));\n  required int32 pqr (INT(16, false));\n  required int32 stu (INT(32, false));\n  required int64 vwx (INT(64, false));\n  required boolean yz;\n}\n",
+		},
+		"optional type": {
+			Input: struct {
+				Foo *int
+			}{},
+			ExpectErr:      false,
+			ExpectedOutput: "message autogen_schema {\n  optional int32 foo (INT(32, true));\n}\n",
+		},
+		"struct pointer": {
+			Input: (*struct {
+				Foo int
+			})(nil),
+			ExpectErr:      false,
+			ExpectedOutput: "message autogen_schema {\n  required int32 foo (INT(32, true));\n}\n",
+		},
+		"structs within struct": {
+			Input: (*struct {
+				Foo *struct {
+					Bar int32
+				}
+				Baz struct {
+					Quux int64
+				}
+			})(nil),
+			ExpectErr:      false,
+			ExpectedOutput: "message autogen_schema {\n  optional group foo {\n    required int32 bar (INT(32, true));\n  }\n  required group baz {\n    required int64 quux (INT(64, true));\n  }\n}\n",
+		},
+		"slices": {
+			Input: (*struct {
+				Foo []int
+				Bar []*int
+				Baz []struct {
+					Quux int
+				}
+				Bla []*struct {
+					Fasel *int
+				}
+			})(nil),
+			ExpectErr:      false,
+			ExpectedOutput: "message autogen_schema {\n  required group foo (LIST) {\n    repeated int32 list (INT(32, true));\n  }\n  optional group bar (LIST) {\n    repeated int32 list (INT(32, true));\n  }\n  required group baz (LIST) {\n    repeated group list {\n      required int32 quux (INT(32, true));\n    }\n  }\n  optional group bla (LIST) {\n    repeated group list {\n      optional int32 fasel (INT(32, true));\n    }\n  }\n}\n",
+		},
+		"byte slices": {
+			Input: (*struct {
+				Foo []byte
+				Bar *[]byte
+			})(nil),
+			ExpectErr:      false,
+			ExpectedOutput: "message autogen_schema {\n  required binary foo;\n  optional binary bar;\n}\n",
+		},
+		"struct tags": {
+			Input: (*struct {
+				Foo []byte  `parquet:"foobar"`
+				Bar *[]byte `parquet:"barman"`
+				Baz int64   `parquet:"bazinga"`
+			})(nil),
+			ExpectErr:      false,
+			ExpectedOutput: "message autogen_schema {\n  required binary foobar;\n  optional binary barman;\n  required int64 bazinga (INT(64, true));\n}\n",
+		},
+		"byte array": {
+			Input: (*struct {
+				Foo [23]byte
+				Bar *[42]byte
+			})(nil),
+			ExpectErr:      false,
+			ExpectedOutput: "message autogen_schema {\n  required fixed_len_byte_array(23) foo;\n  optional fixed_len_byte_array(42) bar;\n}\n",
+		},
+		"simple map": {
+			Input: (*struct {
+				Foo map[string]int64
+			})(nil),
+			ExpectErr:      false,
+			ExpectedOutput: "message autogen_schema {\n  optional group foo (MAP) {\n    repeated group key_value (MAP_KEY_VALUE) {\n      required binary key (STRING);\n      required int64 value (INT(64, true));\n    }\n  }\n}\n",
+		},
+		"chan": {
+			Input: (*struct {
+				Foo chan int
+			})(nil),
+			ExpectErr: true,
+		},
+		"func": {
+			Input: (*struct {
+				Foo func()
+			})(nil),
+			ExpectErr: true,
+		},
+		"interface": {
+			Input: (*struct {
+				Foo interface{}
+			})(nil),
+			ExpectErr: true,
+		},
+		"unsafe.Pointer": {
+			Input: (*struct {
+				Foo unsafe.Pointer
+			})(nil),
+			ExpectErr: true,
+		},
+		"complex64": {
+			Input: (*struct {
+				Foo complex64
+			})(nil),
+			ExpectErr: true,
+		},
+		"complex128": {
+			Input: (*struct {
+				Foo complex128
+			})(nil),
+			ExpectErr: true,
+		},
+		"uintptr": {
+			Input: (*struct {
+				Foo uintptr
+			})(nil),
+			ExpectErr: true,
+		},
+		"invalid struct within struct": {
+			Input: (*struct {
+				Foo struct {
+					Bar uintptr
+				}
+			})(nil),
+			ExpectErr: true,
+		},
+		"invalid slice": {
+			Input: (*struct {
+				Foo []chan int
+			})(nil),
+			ExpectErr: true,
+		},
+		"invalid pointer": {
+			Input: (*struct {
+				Foo *complex128
+			})(nil),
+			ExpectErr: true,
+		},
+		"invalid map key": {
+			Input: (*struct {
+				Foo map[complex128]string
+			})(nil),
+			ExpectErr: true,
+		},
+		"invalid map value": {
+			Input: (*struct {
+				Foo map[string]complex64
+			})(nil),
+			ExpectErr: true,
+		},
+		"non-struct input": {
+			Input:     int64(42),
+			ExpectErr: true,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			output, err := GenerateSchema(testData.Input)
+			if testData.ExpectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, testData.ExpectedOutput, output.String())
+			}
+		})
+	}
+}

--- a/parquetschema/autoschema/gen_test.go
+++ b/parquetschema/autoschema/gen_test.go
@@ -74,6 +74,20 @@ func TestGenerateSchema(t *testing.T) {
 			ExpectErr:      false,
 			ExpectedOutput: "message autogen_schema {\n  required group foo (LIST) {\n    repeated group list {\n      required int64 element (INT(64, true));\n    }\n  }\n  optional group bar (LIST) {\n    repeated group list {\n      required int64 element (INT(64, true));\n    }\n  }\n  required group baz (LIST) {\n    repeated group list {\n      required group element {\n        required int64 quux (INT(64, true));\n      }\n    }\n  }\n  optional group bla (LIST) {\n    repeated group list {\n      required group element {\n        optional int64 fasel (INT(64, true));\n      }\n    }\n  }\n}\n",
 		},
+		"arrays": {
+			Input: (*struct {
+				Foo [1]int
+				Bar [10]*int
+				Baz [5]struct {
+					Quux int
+				}
+				Bla [23]*struct {
+					Fasel *int
+				}
+			})(nil),
+			ExpectErr:      false,
+			ExpectedOutput: "message autogen_schema {\n  required group foo (LIST) {\n    repeated group list {\n      required int64 element (INT(64, true));\n    }\n  }\n  optional group bar (LIST) {\n    repeated group list {\n      required int64 element (INT(64, true));\n    }\n  }\n  required group baz (LIST) {\n    repeated group list {\n      required group element {\n        required int64 quux (INT(64, true));\n      }\n    }\n  }\n  optional group bla (LIST) {\n    repeated group list {\n      required group element {\n        optional int64 fasel (INT(64, true));\n      }\n    }\n  }\n}\n",
+		},
 		"byte slices": {
 			Input: (*struct {
 				Foo []byte

--- a/parquetschema/autoschema/gen_test.go
+++ b/parquetschema/autoschema/gen_test.go
@@ -2,6 +2,7 @@ package autoschema
 
 import (
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/stretchr/testify/require"
@@ -182,6 +183,12 @@ func TestGenerateSchema(t *testing.T) {
 		"non-struct input": {
 			Input:     int64(42),
 			ExpectErr: true,
+		},
+		"time.Time": {
+			Input: (*struct {
+				Foo time.Time
+			})(nil),
+			ExpectedOutput: "message autogen_schema {\n  required int64 foo (TIMESTAMP(NANOS, true));\n}\n",
 		},
 	}
 

--- a/parquetschema/autoschema/gen_test.go
+++ b/parquetschema/autoschema/gen_test.go
@@ -32,21 +32,21 @@ func TestGenerateSchema(t *testing.T) {
 				Xyz  bool
 			}{},
 			ExpectErr:      false,
-			ExpectedOutput: "message autogen_schema {\n  required binary foo (STRING);\n  required int32 bar (INT(32, true));\n  required int32 baz (INT(32, false));\n  required double quux;\n  required int64 bla (INT(64, true));\n  required int64 abc (INT(64, false));\n  required float def;\n  required int32 ghi (INT(32, true));\n  required int32 jkl (INT(32, false));\n  required int32 mno (INT(16, true));\n  required int32 pqr (INT(16, false));\n  required int32 rst (INT(8, true));\n  required int32 uvw (INT(8, false));\n  required boolean xyz;\n}\n",
+			ExpectedOutput: "message autogen_schema {\n  required binary foo (STRING);\n  required int64 bar (INT(64, true));\n  required int32 baz (INT(32, false));\n  required double quux;\n  required int64 bla (INT(64, true));\n  required int64 abc (INT(64, false));\n  required float def;\n  required int32 ghi (INT(32, true));\n  required int32 jkl (INT(32, false));\n  required int32 mno (INT(16, true));\n  required int32 pqr (INT(16, false));\n  required int32 rst (INT(8, true));\n  required int32 uvw (INT(8, false));\n  required boolean xyz;\n}\n",
 		},
 		"optional type": {
 			Input: struct {
 				Foo *int
 			}{},
 			ExpectErr:      false,
-			ExpectedOutput: "message autogen_schema {\n  optional int32 foo (INT(32, true));\n}\n",
+			ExpectedOutput: "message autogen_schema {\n  optional int64 foo (INT(64, true));\n}\n",
 		},
 		"struct pointer": {
 			Input: (*struct {
 				Foo int
 			})(nil),
 			ExpectErr:      false,
-			ExpectedOutput: "message autogen_schema {\n  required int32 foo (INT(32, true));\n}\n",
+			ExpectedOutput: "message autogen_schema {\n  required int64 foo (INT(64, true));\n}\n",
 		},
 		"structs within struct": {
 			Input: (*struct {
@@ -72,7 +72,7 @@ func TestGenerateSchema(t *testing.T) {
 				}
 			})(nil),
 			ExpectErr:      false,
-			ExpectedOutput: "message autogen_schema {\n  required group foo (LIST) {\n    repeated group list {\n      required int32 element (INT(32, true));\n    }\n  }\n  optional group bar (LIST) {\n    repeated group list {\n      required int32 element (INT(32, true));\n    }\n  }\n  required group baz (LIST) {\n    repeated group list {\n      required group element {\n        required int32 quux (INT(32, true));\n      }\n    }\n  }\n  optional group bla (LIST) {\n    repeated group list {\n      required group element {\n        optional int32 fasel (INT(32, true));\n      }\n    }\n  }\n}\n",
+			ExpectedOutput: "message autogen_schema {\n  required group foo (LIST) {\n    repeated group list {\n      required int64 element (INT(64, true));\n    }\n  }\n  optional group bar (LIST) {\n    repeated group list {\n      required int64 element (INT(64, true));\n    }\n  }\n  required group baz (LIST) {\n    repeated group list {\n      required group element {\n        required int64 quux (INT(64, true));\n      }\n    }\n  }\n  optional group bla (LIST) {\n    repeated group list {\n      required group element {\n        optional int64 fasel (INT(64, true));\n      }\n    }\n  }\n}\n",
 		},
 		"byte slices": {
 			Input: (*struct {

--- a/parquetschema/autoschema/gen_test.go
+++ b/parquetschema/autoschema/gen_test.go
@@ -72,7 +72,7 @@ func TestGenerateSchema(t *testing.T) {
 				}
 			})(nil),
 			ExpectErr:      false,
-			ExpectedOutput: "message autogen_schema {\n  required group foo (LIST) {\n    repeated int32 list (INT(32, true));\n  }\n  optional group bar (LIST) {\n    repeated int32 list (INT(32, true));\n  }\n  required group baz (LIST) {\n    repeated group list {\n      required int32 quux (INT(32, true));\n    }\n  }\n  optional group bla (LIST) {\n    repeated group list {\n      optional int32 fasel (INT(32, true));\n    }\n  }\n}\n",
+			ExpectedOutput: "message autogen_schema {\n  required group foo (LIST) {\n    repeated group list {\n      required int32 element (INT(32, true));\n    }\n  }\n  optional group bar (LIST) {\n    repeated group list {\n      required int32 element (INT(32, true));\n    }\n  }\n  required group baz (LIST) {\n    repeated group list {\n      required group element {\n        required int32 quux (INT(32, true));\n      }\n    }\n  }\n  optional group bla (LIST) {\n    repeated group list {\n      required group element {\n        optional int32 fasel (INT(32, true));\n      }\n    }\n  }\n}\n",
 		},
 		"byte slices": {
 			Input: (*struct {

--- a/parquetschema/autoschema/gen_test.go
+++ b/parquetschema/autoschema/gen_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestGenerateSchema(t *testing.T) {
-
 	tests := map[string]struct {
 		Input          interface{}
 		ExpectErr      bool
@@ -16,23 +15,23 @@ func TestGenerateSchema(t *testing.T) {
 	}{
 		"simple types": {
 			Input: struct {
-				Foo  int
-				Bar  uint
-				Baz  string
-				Quux float32
-				Bla  float64
-				Abc  int8
-				Def  int16
+				Foo  string
+				Bar  int
+				Baz  uint
+				Quux float64
+				Bla  int64
+				Abc  uint64
+				Def  float32
 				Ghi  int32
-				Jkl  int64
-				Mno  uint8
+				Jkl  uint32
+				Mno  int16
 				Pqr  uint16
-				Stu  uint32
-				Vwx  uint64
-				Yz   bool
+				Rst  int8
+				Uvw  uint8
+				Xyz  bool
 			}{},
 			ExpectErr:      false,
-			ExpectedOutput: "message autogen_schema {\n  required int32 foo (INT(32, true));\n  required int32 bar (INT(32, false));\n  required binary baz (STRING);\n  required float quux;\n  required double bla;\n  required int32 abc (INT(8, true));\n  required int32 def (INT(16, true));\n  required int32 ghi (INT(32, true));\n  required int64 jkl (INT(64, true));\n  required int32 mno (INT(8, false));\n  required int32 pqr (INT(16, false));\n  required int32 stu (INT(32, false));\n  required int64 vwx (INT(64, false));\n  required boolean yz;\n}\n",
+			ExpectedOutput: "message autogen_schema {\n  required binary foo (STRING);\n  required int32 bar (INT(32, true));\n  required int32 baz (INT(32, false));\n  required double quux;\n  required int64 bla (INT(64, true));\n  required int64 abc (INT(64, false));\n  required float def;\n  required int32 ghi (INT(32, true));\n  required int32 jkl (INT(32, false));\n  required int32 mno (INT(16, true));\n  required int32 pqr (INT(16, false));\n  required int32 rst (INT(8, true));\n  required int32 uvw (INT(8, false));\n  required boolean xyz;\n}\n",
 		},
 		"optional type": {
 			Input: struct {


### PR DESCRIPTION
This PR adds an `autoschema` package that uses reflection to automatically generate schemas. The idea is to be eventually fully compatible with `floor`'s reflection marshaller/unmarshaller, but even though I added some tests to validate this, validation is incomplete so far.