### PR TITLE
Prevent Copying Schema on every Write + Read

### DIFF
--- a/floor/writer_test.go
+++ b/floor/writer_test.go
@@ -588,7 +588,7 @@ func BenchmarkWriteFile(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		hlWriter.Write(data)
+		_ = hlWriter.Write(data)
 	}
 }
 

--- a/schema.go
+++ b/schema.go
@@ -931,12 +931,7 @@ func createColumnDefinitionFromColumn(c *Column) *parquetschema.ColumnDefinition
 }
 
 func (r *schema) GetSchemaDefinition() *parquetschema.SchemaDefinition {
-	def, err := parquetschema.ParseSchemaDefinition(r.schemaDef.String())
-	if err != nil {
-		panic(err)
-	}
-
-	return def
+	return r.schemaDef
 }
 
 // DataSize return the size of data stored in the schema right now


### PR DESCRIPTION
## PR
This changes `GetSchemaDefinition` to NOT serialize the schema to a `string` and then immediately parse it back to a `schema` definition on every `Write` and every `Read`(scan) of data. 

Perhaps there's a reason that I'm not understanding but I could not determine any reason why this would be needed.

I do see there's another similar change that's been merged yet unreleased but this PR handles it at the lower `schema` level and will apply to both the `reader` and `writer` at the core of the copy.

Changes Benchmarked:
### BEFORE
```
goos: darwin
goarch: amd64
pkg: github.com/fraugster/parquet-go/floor
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkReadFile-12               83163             13852 ns/op            2153 B/op         79 allocs/op
BenchmarkWriteFile-12              21464             55469 ns/op           10280 B/op        250 allocs/op

= 18,028 writes/s
= 72,191 reads/s
```

### AFTER
```
goos: darwin
goarch: amd64
pkg: github.com/fraugster/parquet-go/floor
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkReadFile-12              681856              1534 ns/op             544 B/op         35 allocs/op
BenchmarkWriteFile-12             237277              4926 ns/op            4176 B/op         89 allocs/op

= 203,004 writes/s
= 651,890 reads/s
```