### PR TITLE
fully relax schema field name parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - perf - cache result of GetSchemaDefinition call
 - updated readme, added special mentions section
+- Relax schema parser requirement that field names begin with a letter or underscore.
 
 ## [v0.6.0] - 2021-11-3
 - Added a schema generator which uses reflection to automatically generate a parquet schema from a go object.

--- a/parquetschema/schema_parser.go
+++ b/parquetschema/schema_parser.go
@@ -152,11 +152,6 @@ func (l *schemaLexer) acceptRun(valid string) {
 	l.backup()
 }
 
-func (l *schemaLexer) errorf(format string, args ...interface{}) stateFn {
-	l.items <- item{itemError, l.start, fmt.Sprintf(format, args...), l.startLine}
-	return nil
-}
-
 func (l *schemaLexer) nextItem() item {
 	return <-l.items
 }
@@ -208,10 +203,8 @@ func lexText(l *schemaLexer) stateFn {
 		l.emit(itemSemicolon)
 	case r == ',':
 		l.emit(itemComma)
-	case isAlpha(r):
-		return lexIdentifier
 	default:
-		l.errorf("unknown start of token '%v'", r)
+		return lexIdentifier
 	}
 	return lexText
 }
@@ -222,10 +215,6 @@ func isSpace(r rune) bool {
 
 func isDigit(r rune) bool {
 	return unicode.IsDigit(r)
-}
-
-func isAlpha(r rune) bool {
-	return r == '_' || unicode.IsLetter(r)
 }
 
 func isSchemaDelim(r rune) bool {

--- a/parquetschema/schema_parser_test.go
+++ b/parquetschema/schema_parser_test.go
@@ -38,7 +38,7 @@ func TestSchemaParser(t *testing.T) {
 			optional boolean is_fraud = 7;
 		}`, false, false},
 		// 10.
-		{`message $ { }`, true, false},                              // $ is not the start of a valid token.
+		{`message $ { }`, false, false},                             // unusual token
 		{`message foo { optional int128 bar; }`, true, false},       // invalid type
 		{`message foo { optional int64 bar (BLUB); }`, true, false}, // invalid logical type
 		{`message foo { optional int32 bar; }`, false, false},


### PR DESCRIPTION
The schema parser requires that identifiers begin with a letter or
underscore.  This differs from the Java and Rust schema parsers, which
require only that identifiers contain no schema delimiter characters.
Relax the requirement here accordingly.