### PR TITLE
remove unsigned support from all interger encodings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - perf - cache result of GetSchemaDefinition call
 - updated readme, added special mentions section
+- Remove unsigned support from all integer encodings.
 
 ## [v0.6.0] - 2021-11-3
 - Added a schema generator which uses reflection to automatically generate a parquet schema from a go object.

--- a/chunk_reader.go
+++ b/chunk_reader.go
@@ -28,27 +28,9 @@ func getDictValuesDecoder(typ *parquet.SchemaElement) (valuesDecoder, error) {
 	case parquet.Type_DOUBLE:
 		return &doublePlainDecoder{}, nil
 	case parquet.Type_INT32:
-		var unSigned bool
-		if typ.ConvertedType != nil {
-			if *typ.ConvertedType == parquet.ConvertedType_UINT_8 || *typ.ConvertedType == parquet.ConvertedType_UINT_16 || *typ.ConvertedType == parquet.ConvertedType_UINT_32 {
-				unSigned = true
-			}
-		}
-		if typ.LogicalType != nil && typ.LogicalType.INTEGER != nil && !typ.LogicalType.INTEGER.IsSigned {
-			unSigned = true
-		}
-		return &int32PlainDecoder{unSigned: unSigned}, nil
+		return &int32PlainDecoder{}, nil
 	case parquet.Type_INT64:
-		var unSigned bool
-		if typ.ConvertedType != nil {
-			if *typ.ConvertedType == parquet.ConvertedType_UINT_64 {
-				unSigned = true
-			}
-		}
-		if typ.LogicalType != nil && typ.LogicalType.INTEGER != nil && !typ.LogicalType.INTEGER.IsSigned {
-			unSigned = true
-		}
-		return &int64PlainDecoder{unSigned: unSigned}, nil
+		return &int64PlainDecoder{}, nil
 	case parquet.Type_INT96:
 		return &int96PlainDecoder{}, nil
 	}
@@ -98,20 +80,11 @@ func getFixedLenByteArrayValuesDecoder(pageEncoding parquet.Encoding, len int, d
 }
 
 func getInt32ValuesDecoder(pageEncoding parquet.Encoding, typ *parquet.SchemaElement, dictValues []interface{}) (valuesDecoder, error) {
-	var unSigned bool
-	if typ.ConvertedType != nil {
-		if *typ.ConvertedType == parquet.ConvertedType_UINT_8 || *typ.ConvertedType == parquet.ConvertedType_UINT_16 || *typ.ConvertedType == parquet.ConvertedType_UINT_32 {
-			unSigned = true
-		}
-	}
-	if typ.LogicalType != nil && typ.LogicalType.INTEGER != nil && !typ.LogicalType.INTEGER.IsSigned {
-		unSigned = true
-	}
 	switch pageEncoding {
 	case parquet.Encoding_PLAIN:
-		return &int32PlainDecoder{unSigned: unSigned}, nil
+		return &int32PlainDecoder{}, nil
 	case parquet.Encoding_DELTA_BINARY_PACKED:
-		return &int32DeltaBPDecoder{unSigned: unSigned}, nil
+		return &int32DeltaBPDecoder{}, nil
 	case parquet.Encoding_RLE_DICTIONARY:
 		return &dictDecoder{values: dictValues}, nil
 	default:
@@ -120,20 +93,11 @@ func getInt32ValuesDecoder(pageEncoding parquet.Encoding, typ *parquet.SchemaEle
 }
 
 func getInt64ValuesDecoder(pageEncoding parquet.Encoding, typ *parquet.SchemaElement, dictValues []interface{}) (valuesDecoder, error) {
-	var unSigned bool
-	if typ.ConvertedType != nil {
-		if *typ.ConvertedType == parquet.ConvertedType_UINT_64 {
-			unSigned = true
-		}
-	}
-	if typ.LogicalType != nil && typ.LogicalType.INTEGER != nil && !typ.LogicalType.INTEGER.IsSigned {
-		unSigned = true
-	}
 	switch pageEncoding {
 	case parquet.Encoding_PLAIN:
-		return &int64PlainDecoder{unSigned: unSigned}, nil
+		return &int64PlainDecoder{}, nil
 	case parquet.Encoding_DELTA_BINARY_PACKED:
-		return &int64DeltaBPDecoder{unSigned: unSigned}, nil
+		return &int64DeltaBPDecoder{}, nil
 	case parquet.Encoding_RLE_DICTIONARY:
 		return &dictDecoder{values: dictValues}, nil
 	default:

--- a/chunk_writer.go
+++ b/chunk_writer.go
@@ -50,20 +50,11 @@ func getFixedLenByteArrayValuesEncoder(pageEncoding parquet.Encoding, len int, s
 }
 
 func getInt32ValuesEncoder(pageEncoding parquet.Encoding, typ *parquet.SchemaElement, store *dictStore) (valuesEncoder, error) {
-	var unSigned bool
-	if typ.ConvertedType != nil {
-		if *typ.ConvertedType == parquet.ConvertedType_UINT_8 || *typ.ConvertedType == parquet.ConvertedType_UINT_16 || *typ.ConvertedType == parquet.ConvertedType_UINT_32 {
-			unSigned = true
-		}
-	}
-	if typ.LogicalType != nil && typ.LogicalType.INTEGER != nil && !typ.LogicalType.INTEGER.IsSigned {
-		unSigned = true
-	}
 	switch pageEncoding {
 	case parquet.Encoding_PLAIN:
-		return &int32PlainEncoder{unSigned: unSigned}, nil
+		return &int32PlainEncoder{}, nil
 	case parquet.Encoding_DELTA_BINARY_PACKED:
-		return &int32DeltaBPEncoder{unSigned: unSigned}, nil
+		return &int32DeltaBPEncoder{}, nil
 	case parquet.Encoding_RLE_DICTIONARY:
 		return &dictEncoder{
 			dictStore: *store,
@@ -74,20 +65,11 @@ func getInt32ValuesEncoder(pageEncoding parquet.Encoding, typ *parquet.SchemaEle
 }
 
 func getInt64ValuesEncoder(pageEncoding parquet.Encoding, typ *parquet.SchemaElement, store *dictStore) (valuesEncoder, error) {
-	var unSigned bool
-	if typ.ConvertedType != nil {
-		if *typ.ConvertedType == parquet.ConvertedType_UINT_64 {
-			unSigned = true
-		}
-	}
-	if typ.LogicalType != nil && typ.LogicalType.INTEGER != nil && !typ.LogicalType.INTEGER.IsSigned {
-		unSigned = true
-	}
 	switch pageEncoding {
 	case parquet.Encoding_PLAIN:
-		return &int64PlainEncoder{unSigned: unSigned}, nil
+		return &int64PlainEncoder{}, nil
 	case parquet.Encoding_DELTA_BINARY_PACKED:
-		return &int64DeltaBPEncoder{unSigned: unSigned}, nil
+		return &int64DeltaBPEncoder{}, nil
 	case parquet.Encoding_RLE_DICTIONARY:
 		return &dictEncoder{
 			dictStore: *store,
@@ -173,27 +155,9 @@ func getDictValuesEncoder(typ *parquet.SchemaElement) (valuesEncoder, error) {
 	case parquet.Type_DOUBLE:
 		return &doublePlainEncoder{}, nil
 	case parquet.Type_INT32:
-		var unSigned bool
-		if typ.ConvertedType != nil {
-			if *typ.ConvertedType == parquet.ConvertedType_UINT_8 || *typ.ConvertedType == parquet.ConvertedType_UINT_16 || *typ.ConvertedType == parquet.ConvertedType_UINT_32 {
-				unSigned = true
-			}
-		}
-		if typ.LogicalType != nil && typ.LogicalType.INTEGER != nil && !typ.LogicalType.INTEGER.IsSigned {
-			unSigned = true
-		}
-		return &int32PlainEncoder{unSigned: unSigned}, nil
+		return &int32PlainEncoder{}, nil
 	case parquet.Type_INT64:
-		var unSigned bool
-		if typ.ConvertedType != nil {
-			if *typ.ConvertedType == parquet.ConvertedType_UINT_64 {
-				unSigned = true
-			}
-		}
-		if typ.LogicalType != nil && typ.LogicalType.INTEGER != nil && !typ.LogicalType.INTEGER.IsSigned {
-			unSigned = true
-		}
-		return &int64PlainEncoder{unSigned: unSigned}, nil
+		return &int64PlainEncoder{}, nil
 	case parquet.Type_INT96:
 		return &int96PlainEncoder{}, nil
 	}

--- a/type_int32.go
+++ b/type_int32.go
@@ -10,8 +10,7 @@ import (
 )
 
 type int32PlainDecoder struct {
-	unSigned bool
-	r        io.Reader
+	r io.Reader
 }
 
 func (i *int32PlainDecoder) init(r io.Reader) error {
@@ -33,8 +32,7 @@ func (i *int32PlainDecoder) decodeValues(dst []interface{}) (int, error) {
 }
 
 type int32PlainEncoder struct {
-	unSigned bool
-	w        io.Writer
+	w io.Writer
 }
 
 func (i *int32PlainEncoder) Close() error {
@@ -56,7 +54,6 @@ func (i *int32PlainEncoder) encodeValues(values []interface{}) error {
 }
 
 type int32DeltaBPDecoder struct {
-	unSigned bool
 	deltaBitPackDecoder32
 }
 
@@ -66,33 +63,20 @@ func (d *int32DeltaBPDecoder) decodeValues(dst []interface{}) (int, error) {
 		if err != nil {
 			return i, err
 		}
-		if d.unSigned {
-			dst[i] = uint32(u)
-		} else {
-			dst[i] = u
-		}
+		dst[i] = u
 	}
 
 	return len(dst), nil
 }
 
 type int32DeltaBPEncoder struct {
-	unSigned bool
 	deltaBitPackEncoder32
 }
 
 func (d *int32DeltaBPEncoder) encodeValues(values []interface{}) error {
-	if d.unSigned {
-		for i := range values {
-			if err := d.addInt32(int32(values[i].(uint32))); err != nil {
-				return err
-			}
-		}
-	} else {
-		for i := range values {
-			if err := d.addInt32(values[i].(int32)); err != nil {
-				return err
-			}
+	for i := range values {
+		if err := d.addInt32(values[i].(int32)); err != nil {
+			return err
 		}
 	}
 

--- a/type_int64.go
+++ b/type_int64.go
@@ -10,8 +10,7 @@ import (
 )
 
 type int64PlainDecoder struct {
-	unSigned bool
-	r        io.Reader
+	r io.Reader
 }
 
 func (i *int64PlainDecoder) init(r io.Reader) error {
@@ -27,18 +26,13 @@ func (i *int64PlainDecoder) decodeValues(dst []interface{}) (int, error) {
 		if err := binary.Read(i.r, binary.LittleEndian, &d); err != nil {
 			return idx, err
 		}
-		if i.unSigned {
-			dst[idx] = uint64(d)
-		} else {
-			dst[idx] = d
-		}
+		dst[idx] = d
 	}
 	return len(dst), nil
 }
 
 type int64PlainEncoder struct {
-	unSigned bool
-	w        io.Writer
+	w io.Writer
 }
 
 func (i *int64PlainEncoder) Close() error {
@@ -53,20 +47,13 @@ func (i *int64PlainEncoder) init(w io.Writer) error {
 
 func (i *int64PlainEncoder) encodeValues(values []interface{}) error {
 	d := make([]int64, len(values))
-	if i.unSigned {
-		for i := range values {
-			d[i] = int64(values[i].(uint64))
-		}
-	} else {
-		for i := range values {
-			d[i] = values[i].(int64)
-		}
+	for i := range values {
+		d[i] = values[i].(int64)
 	}
 	return binary.Write(i.w, binary.LittleEndian, d)
 }
 
 type int64DeltaBPDecoder struct {
-	unSigned bool
 	deltaBitPackDecoder64
 }
 
@@ -76,34 +63,20 @@ func (d *int64DeltaBPDecoder) decodeValues(dst []interface{}) (int, error) {
 		if err != nil {
 			return i, err
 		}
-		if d.unSigned {
-			dst[i] = uint64(u)
-		} else {
-			dst[i] = u
-		}
+		dst[i] = u
 	}
 
 	return len(dst), nil
 }
 
 type int64DeltaBPEncoder struct {
-	unSigned bool
-
 	deltaBitPackEncoder64
 }
 
 func (d *int64DeltaBPEncoder) encodeValues(values []interface{}) error {
-	if d.unSigned {
-		for i := range values {
-			if err := d.addInt64(int64(values[i].(uint64))); err != nil {
-				return err
-			}
-		}
-	} else {
-		for i := range values {
-			if err := d.addInt64(values[i].(int64)); err != nil {
-				return err
-			}
+	for i := range values {
+		if err := d.addInt64(values[i].(int64)); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
#29 removed unsigned support from int32PlainEncoder and
int32PlainDecoder but not from the other integer encodings, resulting in
some inconsistent behavior.  Finish the job by removing it from all
integer encodings.