### PR TITLE
Fix delta bit-packed encoding of int32 and int64

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,4 +61,7 @@ issues:
     - path: ".*_test.go"
       text: "Use of weak random number generator"
       linters: [gosec]
+    - path: ".*_test.go"
+      text: "shadows declaration"
+      linters: [govet]
 

--- a/chunk_writer.go
+++ b/chunk_writer.go
@@ -54,7 +54,12 @@ func getInt32ValuesEncoder(pageEncoding parquet.Encoding, typ *parquet.SchemaEle
 	case parquet.Encoding_PLAIN:
 		return &int32PlainEncoder{}, nil
 	case parquet.Encoding_DELTA_BINARY_PACKED:
-		return &int32DeltaBPEncoder{}, nil
+		return &int32DeltaBPEncoder{
+			deltaBitPackEncoder32: deltaBitPackEncoder32{
+				blockSize:      128,
+				miniBlockCount: 4,
+			},
+		}, nil
 	case parquet.Encoding_RLE_DICTIONARY:
 		return &dictEncoder{
 			dictStore: *store,
@@ -69,7 +74,12 @@ func getInt64ValuesEncoder(pageEncoding parquet.Encoding, typ *parquet.SchemaEle
 	case parquet.Encoding_PLAIN:
 		return &int64PlainEncoder{}, nil
 	case parquet.Encoding_DELTA_BINARY_PACKED:
-		return &int64DeltaBPEncoder{}, nil
+		return &int64DeltaBPEncoder{
+			deltaBitPackEncoder64: deltaBitPackEncoder64{
+				blockSize:      128,
+				miniBlockCount: 4,
+			},
+		}, nil
 	case parquet.Encoding_RLE_DICTIONARY:
 		return &dictEncoder{
 			dictStore: *store,

--- a/deltabp_encoder.go
+++ b/deltabp_encoder.go
@@ -18,7 +18,7 @@ type deltaBitPackEncoder32 struct {
 	w        io.Writer
 
 	// this value should be there before the init
-	blockSize      int // Must be multiply of 128
+	blockSize      int // Must be multiple of 128
 	miniBlockCount int // blockSize % miniBlockCount should be 0
 
 	miniBlockValueCount int
@@ -35,7 +35,7 @@ func (d *deltaBitPackEncoder32) init(w io.Writer) error {
 	d.w = w
 
 	if d.blockSize%128 != 0 || d.blockSize <= 0 {
-		return errors.Errorf("invalid block size, it should be multiply of 128, it is %d", d.blockSize)
+		return errors.Errorf("invalid block size, it should be multiple of 128, it is %d", d.blockSize)
 	}
 
 	if d.miniBlockCount <= 0 || d.blockSize%d.miniBlockCount != 0 {
@@ -44,7 +44,7 @@ func (d *deltaBitPackEncoder32) init(w io.Writer) error {
 
 	d.miniBlockValueCount = d.blockSize / d.miniBlockCount
 	if d.miniBlockValueCount%8 != 0 {
-		return errors.Errorf("invalid mini block count, the mini block value count should be multiply of 8, it is %d", d.miniBlockCount)
+		return errors.Errorf("invalid mini block count, the mini block value count should be multiple of 8, it is %d", d.miniBlockCount)
 	}
 
 	d.firstValue = 0
@@ -140,7 +140,7 @@ func (d *deltaBitPackEncoder32) addInt32(i int32) error {
 }
 
 func (d *deltaBitPackEncoder32) write() error {
-	if len(d.deltas) > 0 {
+	if d.valuesCount == 1 || len(d.deltas) > 0 {
 		if err := d.flush(); err != nil {
 			return err
 		}
@@ -171,7 +171,7 @@ func (d *deltaBitPackEncoder32) Close() error {
 
 type deltaBitPackEncoder64 struct {
 	// this value should be there before the init
-	blockSize      int // Must be multiply of 128
+	blockSize      int // Must be multiple of 128
 	miniBlockCount int // blockSize % miniBlockCount should be 0
 
 	//
@@ -194,7 +194,7 @@ func (d *deltaBitPackEncoder64) init(w io.Writer) error {
 	d.w = w
 
 	if d.blockSize%128 != 0 || d.blockSize <= 0 {
-		return errors.Errorf("invalid block size, it should be multiply of 128, it is %d", d.blockSize)
+		return errors.Errorf("invalid block size, it should be multiple of 128, it is %d", d.blockSize)
 	}
 
 	if d.miniBlockCount <= 0 || d.blockSize%d.miniBlockCount != 0 {
@@ -203,7 +203,7 @@ func (d *deltaBitPackEncoder64) init(w io.Writer) error {
 
 	d.miniBlockValueCount = d.blockSize / d.miniBlockCount
 	if d.miniBlockValueCount%8 != 0 {
-		return errors.Errorf("invalid mini block count, the mini block value count should be multiply of 8, it is %d", d.miniBlockCount)
+		return errors.Errorf("invalid mini block count, the mini block value count should be multiple of 8, it is %d", d.miniBlockCount)
 	}
 
 	d.firstValue = 0
@@ -299,7 +299,7 @@ func (d *deltaBitPackEncoder64) addInt64(i int64) error {
 }
 
 func (d *deltaBitPackEncoder64) write() error {
-	if len(d.deltas) > 0 {
+	if d.valuesCount == 1 || len(d.deltas) > 0 {
 		if err := d.flush(); err != nil {
 			return err
 		}

--- a/readwrite_test.go
+++ b/readwrite_test.go
@@ -935,7 +935,7 @@ func TestReadWriteDeltaLengthByteArrayEncoding(t *testing.T) {
 	}
 
 	col := NewDataColumn(bas, parquet.FieldRepetitionType_OPTIONAL)
-	if err = wr.AddColumn("name", col); err != nil {
+	if err := wr.AddColumn("name", col); err != nil {
 		t.Fatal(err)
 	}
 
@@ -944,12 +944,12 @@ func TestReadWriteDeltaLengthByteArrayEncoding(t *testing.T) {
 			"name": []byte("dan"),
 		}
 
-		if err = wr.AddData(rec); err != nil {
+		if err := wr.AddData(rec); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	if err = wr.Close(); err != nil {
+	if err := wr.Close(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -981,7 +981,7 @@ func TestReadWriteDeltaBinaryPackedInt32(t *testing.T) {
 	}
 
 	col := NewDataColumn(bas, parquet.FieldRepetitionType_OPTIONAL)
-	if err = wr.AddColumn("number", col); err != nil {
+	if err := wr.AddColumn("number", col); err != nil {
 		t.Fatal(err)
 	}
 
@@ -992,12 +992,12 @@ func TestReadWriteDeltaBinaryPackedInt32(t *testing.T) {
 			"number": int32(42),
 		}
 
-		if err = wr.AddData(rec); err != nil {
+		if err := wr.AddData(rec); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	if err = wr.Close(); err != nil {
+	if err := wr.Close(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1033,7 +1033,7 @@ func TestReadWriteDeltaBinaryPackedInt64(t *testing.T) {
 	}
 
 	col := NewDataColumn(bas, parquet.FieldRepetitionType_OPTIONAL)
-	if err = wr.AddColumn("number", col); err != nil {
+	if err := wr.AddColumn("number", col); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1044,12 +1044,12 @@ func TestReadWriteDeltaBinaryPackedInt64(t *testing.T) {
 			"number": int64(23),
 		}
 
-		if err = wr.AddData(rec); err != nil {
+		if err := wr.AddData(rec); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	if err = wr.Close(); err != nil {
+	if err := wr.Close(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/readwrite_test.go
+++ b/readwrite_test.go
@@ -935,7 +935,7 @@ func TestReadWriteDeltaLengthByteArrayEncoding(t *testing.T) {
 	}
 
 	col := NewDataColumn(bas, parquet.FieldRepetitionType_OPTIONAL)
-	if err := wr.AddColumn("name", col); err != nil {
+	if err = wr.AddColumn("name", col); err != nil {
 		t.Fatal(err)
 	}
 
@@ -944,12 +944,12 @@ func TestReadWriteDeltaLengthByteArrayEncoding(t *testing.T) {
 			"name": []byte("dan"),
 		}
 
-		if err := wr.AddData(rec); err != nil {
+		if err = wr.AddData(rec); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	if err := wr.Close(); err != nil {
+	if err = wr.Close(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -981,7 +981,7 @@ func TestReadWriteDeltaBinaryPackedInt32(t *testing.T) {
 	}
 
 	col := NewDataColumn(bas, parquet.FieldRepetitionType_OPTIONAL)
-	if err := wr.AddColumn("number", col); err != nil {
+	if err = wr.AddColumn("number", col); err != nil {
 		t.Fatal(err)
 	}
 
@@ -992,12 +992,12 @@ func TestReadWriteDeltaBinaryPackedInt32(t *testing.T) {
 			"number": int32(42),
 		}
 
-		if err := wr.AddData(rec); err != nil {
+		if err = wr.AddData(rec); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	if err := wr.Close(); err != nil {
+	if err = wr.Close(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1033,7 +1033,7 @@ func TestReadWriteDeltaBinaryPackedInt64(t *testing.T) {
 	}
 
 	col := NewDataColumn(bas, parquet.FieldRepetitionType_OPTIONAL)
-	if err := wr.AddColumn("number", col); err != nil {
+	if err = wr.AddColumn("number", col); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1044,12 +1044,12 @@ func TestReadWriteDeltaBinaryPackedInt64(t *testing.T) {
 			"number": int64(23),
 		}
 
-		if err := wr.AddData(rec); err != nil {
+		if err = wr.AddData(rec); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	if err := wr.Close(); err != nil {
+	if err = wr.Close(); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
The issue is if only a single value is ever added. In that case, the list of deltas is empty, and flushing them didn't write anything. This is changed so that a flush is done if there are deltas (the common case) or if exactly one value has been added. Looking more closely into this bug, I also discovered the binary bit-packing encoders for int32 and int64 never seemed to have worked properly as the block isze and mini block count never got initialized.

Fixes #27.