### PR TITLE
Improve reading and writing of data pages for better memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Implemented lazy loading of pages.
+- Added support for writing multiple data pages per row group.
+
 ## [v0.8.0] - 2022-02-02
 - Set correct total size and total compressed in row group data.
 - Fixed delta bit-pack encoding of int32 and int64 and delta-length bit-packing encoding of byte\_arrays when only a single value is written.

--- a/chunk_reader.go
+++ b/chunk_reader.go
@@ -350,18 +350,10 @@ func readChunk(ctx context.Context, r io.ReadSeeker, col *Column, chunk *parquet
 
 func readPageData(col *Column, pages []pageReader) error {
 	s := col.getColumnStore()
-	for i := range pages {
-		data, dl, rl, err := pages[i].readValues(int(pages[i].numValues()))
-		if err != nil {
-			return err
-		}
-
-		// using append to make sure we handle the multiple data page correctly
-		s.rLevels.appendArray(rl)
-		s.dLevels.appendArray(dl)
-
-		s.values.values = append(s.values.values, data...)
-		s.values.noDictMode = true
+	s.pageIdx, s.pages = 0, pages
+	s.values.noDictMode = true
+	if err := s.readNextPage(); err != nil {
+		return nil
 	}
 
 	return nil

--- a/data_store.go
+++ b/data_store.go
@@ -123,10 +123,6 @@ func (cs *ColumnStore) add(v interface{}, dL uint16, maxRL, rL uint16) error {
 		}
 	}
 
-	if err := cs.flushPage(false); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/data_store.go
+++ b/data_store.go
@@ -1,7 +1,8 @@
 package goparquet
 
 import (
-	"math"
+	"bytes"
+	"context"
 	"math/bits"
 
 	"github.com/fraugster/parquet-go/parquet"
@@ -28,27 +29,25 @@ type ColumnStore struct {
 	enc     parquet.Encoding
 	readPos int
 
-	allowDict bool
+	useDict bool
 
 	skipped bool
+
+	flushedPages      []flushedPage
+	allDistinctValues map[interface{}]struct{}
+}
+
+type flushedPage struct {
+	compressedSize   int
+	uncompressedSize int
+	numValues        int64
+	nullValues       int64
+	buf              []byte
 }
 
 // useDictionary is simply a function to decide to use dictionary or not,
 func (cs *ColumnStore) useDictionary() bool {
-	if !cs.allowDict {
-		return false
-	}
-	if len(cs.values.data) > math.MaxInt16 {
-		return false
-	}
-
-	// There is no point for using dictionary if all values are nil
-	if len(cs.values.data) == 0 || len(cs.values.values) == 0 {
-		return false
-	}
-
-	dictLen, noDictLen := cs.values.sizes()
-	return dictLen < noDictLen
+	return cs.useDict
 }
 
 func (cs *ColumnStore) encoding() parquet.Encoding {
@@ -86,7 +85,7 @@ func (cs *ColumnStore) appendRDLevel(rl, dl uint16) {
 // Add One row, if the value is null, call Add() , if the value is repeated, call all value in array
 // the second argument s the definition level
 // if there is a data the the result should be true, if there is only null (or empty array), the the result should be false
-func (cs *ColumnStore) add(v interface{}, dL uint16, maxRL, rL uint16) error {
+func (cs *ColumnStore) add(r *schema, col *Column, v interface{}, dL uint16, maxRL, rL uint16) error {
 	// if the current column is repeated, we should increase the maxRL here
 	if cs.repTyp == parquet.FieldRepetitionType_REPEATED {
 		maxRL++
@@ -108,7 +107,7 @@ func (cs *ColumnStore) add(v interface{}, dL uint16, maxRL, rL uint16) error {
 	}
 	if len(vals) == 0 {
 		// the MaxRl might be increased in the beginning and increased again in the next call but for nil its not important
-		return cs.add(nil, dL, maxRL, rL)
+		return cs.add(r, col, nil, dL, maxRL, rL)
 	}
 
 	for i, j := range vals {
@@ -124,6 +123,54 @@ func (cs *ColumnStore) add(v interface{}, dL uint16, maxRL, rL uint16) error {
 			cs.appendRDLevel(maxRL, tmp)
 		}
 	}
+
+	if err := cs.flushPage(r, col, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cs *ColumnStore) estimateSize() (total int64) {
+	dictSize, noDictSize := cs.values.sizes()
+	if cs.useDictionary() {
+		total += dictSize
+	} else {
+		total += noDictSize
+	}
+	total += int64(len(cs.rLevels.data) + len(cs.dLevels.data))
+	return total
+}
+
+func (cs *ColumnStore) flushPage(r *schema, col *Column, force bool) error {
+	size := cs.estimateSize()
+
+	if !force && size < 512*1024 { // TODO: make page size configurable.
+		return nil
+	}
+
+	page := r.newPageFunc(cs.useDictionary())
+
+	if err := page.init(r, col, r.codec); err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+
+	compSize, unCompSize, err := page.write(context.TODO(), &buf)
+	if err != nil {
+		return err
+	}
+
+	cs.flushedPages = append(cs.flushedPages, flushedPage{
+		compressedSize:   compSize,
+		uncompressedSize: unCompSize,
+		numValues:        int64(cs.values.numValues()),
+		nullValues:       int64(cs.values.nullValueCount()),
+		buf:              buf.Bytes(),
+	})
+
+	cs.resetData()
 
 	return nil
 }
@@ -158,6 +205,13 @@ func (cs *ColumnStore) getNext() (v interface{}, err error) {
 	return v, nil
 }
 
+func (cs *ColumnStore) resetData() {
+	cs.readPos = 0
+	cs.values.reset() // this ensures that the values remain for when writing the dictionary page at the end but the data is emptied.
+	cs.rLevels.reset(cs.rLevels.bw)
+	cs.dLevels.reset(cs.dLevels.bw)
+}
+
 func (cs *ColumnStore) readNextPage() error {
 	if cs.pageIdx >= len(cs.pages) {
 		return errors.New("out of range")
@@ -170,15 +224,15 @@ func (cs *ColumnStore) readNextPage() error {
 
 	cs.pageIdx++
 
-	cs.readPos = 0
+	cs.resetData()
 
 	cs.values.readPos = 0
-	cs.values.values = data
-	cs.values.size = int64(len(cs.values.values))
 
-	cs.rLevels.reset(cs.rLevels.bw)
+	for _, v := range data {
+		cs.values.addValue(v, cs.sizeOf(v))
+	}
+
 	cs.rLevels.appendArray(rl)
-	cs.dLevels.reset(cs.dLevels.bw)
 	cs.dLevels.appendArray(dl)
 
 	return nil
@@ -233,10 +287,10 @@ func (cs *ColumnStore) get(maxD, maxR int32) (interface{}, int32, error) {
 	}
 }
 
-func newStore(typed typedColumnStore, enc parquet.Encoding, allowDict bool) *ColumnStore {
+func newStore(typed typedColumnStore, enc parquet.Encoding, useDict bool) *ColumnStore {
 	return &ColumnStore{
 		enc:              enc,
-		allowDict:        allowDict,
+		useDict:          useDict,
 		typedColumnStore: typed,
 	}
 }
@@ -295,34 +349,31 @@ func NewBooleanStore(enc parquet.Encoding, params *ColumnParameters) (*ColumnSto
 	return newStore(&booleanStore{ColumnParameters: params}, enc, false), nil
 }
 
-// NewInt32Store create a new column store to store int32 values. If allowDict is true,
-// then using a dictionary is considered by the column store depending on its heuristics.
-// If allowDict is false, a dictionary will never be used to encode the data.
-func NewInt32Store(enc parquet.Encoding, allowDict bool, params *ColumnParameters) (*ColumnStore, error) {
+// NewInt32Store create a new column store to store int32 values. If useDict is true,
+// then a dictionary is used, otherwise a dictionary will never be used to encode the data.
+func NewInt32Store(enc parquet.Encoding, useDict bool, params *ColumnParameters) (*ColumnStore, error) {
 	switch enc {
 	case parquet.Encoding_PLAIN, parquet.Encoding_DELTA_BINARY_PACKED:
 	default:
 		return nil, errors.Errorf("encoding %q is not supported on this type", enc)
 	}
-	return newStore(&int32Store{ColumnParameters: params}, enc, allowDict), nil
+	return newStore(&int32Store{ColumnParameters: params}, enc, useDict), nil
 }
 
-// NewInt64Store creates a new column store to store int64 values. If allowDict is true,
-// then using a dictionary is considered by the column store depending on its heuristics.
-// If allowDict is false, a dictionary will never be used to encode the data.
-func NewInt64Store(enc parquet.Encoding, allowDict bool, params *ColumnParameters) (*ColumnStore, error) {
+// NewInt64Store creates a new column store to store int64 values. If useDict is true,
+// then a dictionary is used, otherwise a dictionary will never be used to encode the data.
+func NewInt64Store(enc parquet.Encoding, useDict bool, params *ColumnParameters) (*ColumnStore, error) {
 	switch enc {
 	case parquet.Encoding_PLAIN, parquet.Encoding_DELTA_BINARY_PACKED:
 	default:
 		return nil, errors.Errorf("encoding %q is not supported on this type", enc)
 	}
-	return newStore(&int64Store{ColumnParameters: params}, enc, allowDict), nil
+	return newStore(&int64Store{ColumnParameters: params}, enc, useDict), nil
 }
 
-// NewInt96Store creates a new column store to store int96 values. If allowDict is true,
-// then using a dictionary is considered by the column store depending on its heuristics.
-// If allowDict is false, a dictionary will never be used to encode the data.
-func NewInt96Store(enc parquet.Encoding, allowDict bool, params *ColumnParameters) (*ColumnStore, error) {
+// NewInt96Store creates a new column store to store int96 values. If useDict is true,
+// then a dictionary is used, otherwise a dictionary will never be used to encode the data.
+func NewInt96Store(enc parquet.Encoding, useDict bool, params *ColumnParameters) (*ColumnStore, error) {
 	switch enc {
 	case parquet.Encoding_PLAIN:
 	default:
@@ -330,49 +381,45 @@ func NewInt96Store(enc parquet.Encoding, allowDict bool, params *ColumnParameter
 	}
 	store := &int96Store{}
 	store.ColumnParameters = params
-	return newStore(store, enc, allowDict), nil
+	return newStore(store, enc, useDict), nil
 }
 
-// NewFloatStore creates a new column store to store float (float32) values. If allowDict is true,
-// then using a dictionary is considered by the column store depending on its heuristics.
-// If allowDict is false, a dictionary will never be used to encode the data.
-func NewFloatStore(enc parquet.Encoding, allowDict bool, params *ColumnParameters) (*ColumnStore, error) {
+// NewFloatStore creates a new column store to store float (float32) values. If useDict is true,
+// then a dictionary is used, otherwise a dictionary will never be used to encode the data.
+func NewFloatStore(enc parquet.Encoding, useDict bool, params *ColumnParameters) (*ColumnStore, error) {
 	switch enc {
 	case parquet.Encoding_PLAIN:
 	default:
 		return nil, errors.Errorf("encoding %q is not supported on this type", enc)
 	}
-	return newStore(&floatStore{ColumnParameters: params}, enc, allowDict), nil
+	return newStore(&floatStore{ColumnParameters: params}, enc, useDict), nil
 }
 
-// NewDoubleStore creates a new column store to store double (float64) values. If allowDict is true,
-// then using a dictionary is considered by the column store depending on its heuristics.
-// If allowDict is false, a dictionary will never be used to encode the data.
-func NewDoubleStore(enc parquet.Encoding, allowDict bool, params *ColumnParameters) (*ColumnStore, error) {
+// NewDoubleStore creates a new column store to store double (float64) values. If useDict is true,
+// then a dictionary is used, otherwise a dictionary will never be used to encode the data.
+func NewDoubleStore(enc parquet.Encoding, useDict bool, params *ColumnParameters) (*ColumnStore, error) {
 	switch enc {
 	case parquet.Encoding_PLAIN:
 	default:
 		return nil, errors.Errorf("encoding %q is not supported on this type", enc)
 	}
-	return newStore(&doubleStore{ColumnParameters: params}, enc, allowDict), nil
+	return newStore(&doubleStore{ColumnParameters: params}, enc, useDict), nil
 }
 
-// NewByteArrayStore creates a new column store to store byte arrays. If allowDict is true,
-// then using a dictionary is considered by the column store depending on its heuristics.
-// If allowDict is false, a dictionary will never be used to encode the data.
-func NewByteArrayStore(enc parquet.Encoding, allowDict bool, params *ColumnParameters) (*ColumnStore, error) {
+// NewByteArrayStore creates a new column store to store byte arrays. If useDict is true,
+// then a dictionary is used, otherwise a dictionary will never be used to encode the data.
+func NewByteArrayStore(enc parquet.Encoding, useDict bool, params *ColumnParameters) (*ColumnStore, error) {
 	switch enc {
 	case parquet.Encoding_PLAIN, parquet.Encoding_DELTA_LENGTH_BYTE_ARRAY, parquet.Encoding_DELTA_BYTE_ARRAY:
 	default:
 		return nil, errors.Errorf("encoding %q is not supported on this type", enc)
 	}
-	return newStore(&byteArrayStore{ColumnParameters: params}, enc, allowDict), nil
+	return newStore(&byteArrayStore{ColumnParameters: params}, enc, useDict), nil
 }
 
-// NewFixedByteArrayStore creates a new column store to store fixed size byte arrays. If allowDict is true,
-// then using a dictionary is considered by the column store depending on its heuristics.
-// If allowDict is false, a dictionary will never be used to encode the data.
-func NewFixedByteArrayStore(enc parquet.Encoding, allowDict bool, params *ColumnParameters) (*ColumnStore, error) {
+// NewFixedByteArrayStore creates a new column store to store fixed size byte arrays. If useDict is true,
+// then a dictionary is used, otherwise a dictionary will never be used to encode the data.
+func NewFixedByteArrayStore(enc parquet.Encoding, useDict bool, params *ColumnParameters) (*ColumnStore, error) {
 	switch enc {
 	case parquet.Encoding_PLAIN, parquet.Encoding_DELTA_LENGTH_BYTE_ARRAY, parquet.Encoding_DELTA_BYTE_ARRAY:
 	default:
@@ -388,5 +435,5 @@ func NewFixedByteArrayStore(enc parquet.Encoding, allowDict bool, params *Column
 
 	return newStore(&byteArrayStore{
 		ColumnParameters: params,
-	}, enc, allowDict), nil
+	}, enc, useDict), nil
 }

--- a/data_store.go
+++ b/data_store.go
@@ -33,7 +33,7 @@ type ColumnStore struct {
 
 	dataPages []*dataPage
 
-	allDistinctValues map[interface{}]struct{}
+	maxPageSize int64
 }
 
 type dataPage struct {
@@ -137,10 +137,17 @@ func (cs *ColumnStore) estimateSize() (total int64) {
 	return total
 }
 
+func (cs *ColumnStore) getMaxPageSize() int64 {
+	if cs.maxPageSize == 0 {
+		return 1024 * 1024
+	}
+	return cs.maxPageSize
+}
+
 func (cs *ColumnStore) flushPage(force bool) error {
 	size := cs.estimateSize()
 
-	if !force && size < 512*1024 { // TODO: make page size configurable.
+	if !force && size < cs.getMaxPageSize() {
 		return nil
 	}
 

--- a/data_store_test.go
+++ b/data_store_test.go
@@ -32,7 +32,7 @@ func TestOneColumn(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint16(0), d.MaxDefinitionLevel())
 	assert.Equal(t, uint16(0), d.MaxRepetitionLevel())
-	assert.Equal(t, []interface{}{int32(10), int32(20)}, d.data.values.assemble())
+	assert.Equal(t, []interface{}{int32(10), int32(20)}, d.data.values.getValues())
 	assert.Equal(t, []int32{0, 0}, d.data.dLevels.toArray())
 	assert.Equal(t, []int32{0, 0}, d.data.rLevels.toArray())
 
@@ -62,7 +62,7 @@ func TestOneColumnOptional(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint16(1), d.MaxDefinitionLevel())
 	assert.Equal(t, uint16(0), d.MaxRepetitionLevel())
-	assert.Equal(t, []interface{}{int32(10)}, d.data.values.assemble())
+	assert.Equal(t, []interface{}{int32(10)}, d.data.values.getValues())
 	assert.Equal(t, []int32{1, 0}, d.data.dLevels.toArray())
 	assert.Equal(t, []int32{0, 0}, d.data.rLevels.toArray())
 
@@ -90,7 +90,7 @@ func TestOneColumnRepeated(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint16(1), d.MaxDefinitionLevel())
 	assert.Equal(t, uint16(1), d.MaxRepetitionLevel())
-	assert.Equal(t, []interface{}{int32(10), int32(20)}, d.data.values.assemble())
+	assert.Equal(t, []interface{}{int32(10), int32(20)}, d.data.values.getValues())
 	assert.Equal(t, []int32{1, 1, 0}, d.data.dLevels.toArray())
 	assert.Equal(t, []int32{0, 1, 0}, d.data.rLevels.toArray())
 
@@ -149,7 +149,7 @@ func TestComplexPart1(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint16(2), d.MaxDefinitionLevel())
 	assert.Equal(t, uint16(2), d.MaxRepetitionLevel())
-	assert.Equal(t, []interface{}{int32(1), int32(2), int32(3)}, d.data.values.assemble())
+	assert.Equal(t, []interface{}{int32(1), int32(2), int32(3)}, d.data.values.getValues())
 	assert.Equal(t, []int32{2, 2, 1, 2}, d.data.dLevels.toArray())
 	assert.Equal(t, []int32{0, 2, 1, 1}, d.data.rLevels.toArray())
 
@@ -157,7 +157,7 @@ func TestComplexPart1(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint16(3), d.MaxDefinitionLevel())
 	assert.Equal(t, uint16(2), d.MaxRepetitionLevel())
-	assert.Equal(t, []interface{}{int32(100), int32(101)}, d.data.values.assemble())
+	assert.Equal(t, []interface{}{int32(100), int32(101)}, d.data.values.getValues())
 	assert.Equal(t, []int32{3, 2, 1, 3}, d.data.dLevels.toArray())
 	assert.Equal(t, []int32{0, 2, 1, 1}, d.data.rLevels.toArray())
 
@@ -165,7 +165,7 @@ func TestComplexPart1(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint16(2), d.MaxDefinitionLevel())
 	assert.Equal(t, uint16(1), d.MaxRepetitionLevel())
-	assert.Equal(t, []interface{}{int32(10), int32(11)}, d.data.values.assemble())
+	assert.Equal(t, []interface{}{int32(10), int32(11)}, d.data.values.getValues())
 	assert.Equal(t, []int32{2, 2, 1}, d.data.dLevels.toArray())
 	assert.Equal(t, []int32{0, 1, 1}, d.data.rLevels.toArray())
 
@@ -205,7 +205,7 @@ func TestComplexPart2(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint16(2), d.MaxDefinitionLevel())
 	assert.Equal(t, uint16(1), d.MaxRepetitionLevel())
-	assert.Equal(t, []interface{}{int32(20), int32(40), int32(60), int32(80)}, d.data.values.assemble())
+	assert.Equal(t, []interface{}{int32(20), int32(40), int32(60), int32(80)}, d.data.values.getValues())
 	assert.Equal(t, []int32{2, 2, 2, 2}, d.data.dLevels.toArray())
 	assert.Equal(t, []int32{0, 1, 1, 0}, d.data.rLevels.toArray())
 
@@ -213,7 +213,7 @@ func TestComplexPart2(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint16(2), d.MaxDefinitionLevel())
 	assert.Equal(t, uint16(1), d.MaxRepetitionLevel())
-	assert.Equal(t, []interface{}{int32(10), int32(30)}, d.data.values.assemble())
+	assert.Equal(t, []interface{}{int32(10), int32(30)}, d.data.values.getValues())
 	assert.Equal(t, []int32{1, 2, 2}, d.data.dLevels.toArray())
 	assert.Equal(t, []int32{0, 0, 1}, d.data.rLevels.toArray())
 
@@ -292,7 +292,7 @@ func TestComplex(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint16(0), d.MaxDefinitionLevel())
 	assert.Equal(t, uint16(0), d.MaxRepetitionLevel())
-	assert.Equal(t, []interface{}{int32(10), int32(20)}, d.data.values.assemble())
+	assert.Equal(t, []interface{}{int32(10), int32(20)}, d.data.values.getValues())
 	assert.Equal(t, []int32{0, 0}, d.data.dLevels.toArray())
 	assert.Equal(t, []int32{0, 0}, d.data.rLevels.toArray())
 
@@ -300,7 +300,7 @@ func TestComplex(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint16(2), d.MaxDefinitionLevel())
 	assert.Equal(t, uint16(1), d.MaxRepetitionLevel())
-	assert.Equal(t, []interface{}{int32(10), int32(11), int32(12)}, d.data.values.assemble())
+	assert.Equal(t, []interface{}{int32(10), int32(11), int32(12)}, d.data.values.getValues())
 	assert.Equal(t, []int32{2, 2, 1, 2}, d.data.dLevels.toArray())
 	assert.Equal(t, []int32{0, 1, 1, 0}, d.data.rLevels.toArray())
 
@@ -308,7 +308,7 @@ func TestComplex(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint16(2), d.MaxDefinitionLevel())
 	assert.Equal(t, uint16(1), d.MaxRepetitionLevel())
-	assert.Equal(t, []interface{}{int32(20), int32(40), int32(60), int32(80)}, d.data.values.assemble())
+	assert.Equal(t, []interface{}{int32(20), int32(40), int32(60), int32(80)}, d.data.values.getValues())
 	assert.Equal(t, []int32{2, 2, 2, 2}, d.data.dLevels.toArray())
 	assert.Equal(t, []int32{0, 1, 1, 0}, d.data.rLevels.toArray())
 
@@ -316,7 +316,7 @@ func TestComplex(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint16(2), d.MaxDefinitionLevel())
 	assert.Equal(t, uint16(1), d.MaxRepetitionLevel())
-	assert.Equal(t, []interface{}{int32(10), int32(30)}, d.data.values.assemble())
+	assert.Equal(t, []interface{}{int32(10), int32(30)}, d.data.values.getValues())
 	assert.Equal(t, []int32{1, 2, 2}, d.data.dLevels.toArray())
 	assert.Equal(t, []int32{0, 0, 1}, d.data.rLevels.toArray())
 
@@ -324,7 +324,7 @@ func TestComplex(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint16(3), d.MaxDefinitionLevel())
 	assert.Equal(t, uint16(2), d.MaxRepetitionLevel())
-	assert.Equal(t, []interface{}{int32(100), int32(101)}, d.data.values.assemble())
+	assert.Equal(t, []interface{}{int32(100), int32(101)}, d.data.values.getValues())
 	assert.Equal(t, []int32{3, 2, 1, 3, 1}, d.data.dLevels.toArray())
 	assert.Equal(t, []int32{0, 2, 1, 1, 0}, d.data.rLevels.toArray())
 
@@ -332,7 +332,7 @@ func TestComplex(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint16(2), d.MaxDefinitionLevel())
 	assert.Equal(t, uint16(2), d.MaxRepetitionLevel())
-	assert.Equal(t, []interface{}{int32(1), int32(2), int32(3)}, d.data.values.assemble())
+	assert.Equal(t, []interface{}{int32(1), int32(2), int32(3)}, d.data.values.getValues())
 	assert.Equal(t, []int32{2, 2, 1, 2, 1}, d.data.dLevels.toArray())
 	assert.Equal(t, []int32{0, 2, 1, 1, 0}, d.data.rLevels.toArray())
 
@@ -375,7 +375,7 @@ func TestTwitterBlog(t *testing.T) {
 	for i := 1; i < 11; i++ {
 		expected = append(expected, int32(i))
 	}
-	assert.Equal(t, expected, d.data.values.assemble())
+	assert.Equal(t, expected, d.data.values.getValues())
 	assert.Equal(t, uint16(2), d.MaxDefinitionLevel())
 	assert.Equal(t, uint16(2), d.MaxRepetitionLevel())
 	assert.Equal(t, []int32{0, 2, 2, 1, 2, 2, 2, 0, 1, 2}, d.data.rLevels.toArray())
@@ -412,7 +412,7 @@ func TestEmptyParent(t *testing.T) {
 	col, err := row.findDataColumn("baz.list.element")
 	require.NoError(t, err)
 
-	assert.Equal(t, []interface{}{}, col.data.values.assemble())
+	assert.Equal(t, []interface{}(nil), col.data.values.getValues())
 
 	assert.Equal(t, uint16(2), col.MaxDefinitionLevel())
 	assert.Equal(t, uint16(1), col.MaxRepetitionLevel())
@@ -465,7 +465,7 @@ func TestZeroRL(t *testing.T) {
 	d, err := row.findDataColumn("baz.list.element.quux")
 	require.NoError(t, err)
 	var expected = []interface{}{int32(23), int32(42)}
-	assert.Equal(t, expected, d.data.values.assemble())
+	assert.Equal(t, expected, d.data.values.getValues())
 	assert.Equal(t, uint16(1), d.MaxDefinitionLevel())
 	assert.Equal(t, uint16(1), d.MaxRepetitionLevel())
 	assert.Equal(t, []int32{0, 1}, d.data.rLevels.toArray())
@@ -485,7 +485,7 @@ func TestZeroRL(t *testing.T) {
 
 	d, err = row.findDataColumn("baz.list.element.quux")
 	require.NoError(t, err)
-	assert.Equal(t, expected, d.data.values.assemble())
+	assert.Equal(t, expected, d.data.values.getValues())
 	assert.Equal(t, uint16(2), d.MaxDefinitionLevel())
 	assert.Equal(t, uint16(1), d.MaxRepetitionLevel())
 	assert.Equal(t, []int32{0, 1}, d.data.rLevels.toArray())

--- a/file_writer.go
+++ b/file_writer.go
@@ -335,3 +335,7 @@ func (fw *FileWriter) AddColumn(path string, col *Column) error {
 func (fw *FileWriter) AddGroup(path string, rep parquet.FieldRepetitionType) error {
 	return fw.schemaWriter.AddGroup(path, rep)
 }
+
+func (fw *FileWriter) GetSchemaDefinition() *parquetschema.SchemaDefinition {
+	return fw.schemaWriter.GetSchemaDefinition()
+}

--- a/file_writer.go
+++ b/file_writer.go
@@ -44,15 +44,13 @@ func NewFileWriter(w io.Writer, options ...FileWriterOption) *FileWriter {
 			w:   w,
 			pos: 0,
 		},
-		version: 1,
-		SchemaWriter: &schema{
-			newPageFunc: newDataPageV1Writer,
-		},
-		kvStore:     make(map[string]string),
-		rowGroups:   []*parquet.RowGroup{},
-		createdBy:   "parquet-go",
-		newPageFunc: newDataPageV1Writer,
-		ctx:         context.Background(),
+		version:      1,
+		SchemaWriter: &schema{},
+		kvStore:      make(map[string]string),
+		rowGroups:    []*parquet.RowGroup{},
+		createdBy:    "parquet-go",
+		newPageFunc:  newDataPageV1Writer,
+		ctx:          context.Background(),
 	}
 
 	for _, opt := range options {
@@ -80,7 +78,6 @@ func WithCreator(createdBy string) FileWriterOption {
 func WithCompressionCodec(codec parquet.CompressionCodec) FileWriterOption {
 	return func(fw *FileWriter) {
 		fw.codec = codec
-		fw.SchemaWriter.(*schema).codec = codec
 	}
 }
 
@@ -120,7 +117,6 @@ func WithSchemaDefinition(sd *parquetschema.SchemaDefinition) FileWriterOption {
 func WithDataPageV2() FileWriterOption {
 	return func(fw *FileWriter) {
 		fw.newPageFunc = newDataPageV2Writer
-		fw.SchemaWriter.(*schema).newPageFunc = newDataPageV2Writer
 	}
 }
 

--- a/file_writer.go
+++ b/file_writer.go
@@ -16,7 +16,9 @@ type FileWriter struct {
 	w writePos
 
 	version int32
-	SchemaWriter
+	//SchemaWriter
+
+	schemaWriter *schema
 
 	totalNumRecords int64
 	kvStore         map[string]string
@@ -45,7 +47,7 @@ func NewFileWriter(w io.Writer, options ...FileWriterOption) *FileWriter {
 			pos: 0,
 		},
 		version:      1,
-		SchemaWriter: &schema{},
+		schemaWriter: &schema{},
 		kvStore:      make(map[string]string),
 		rowGroups:    []*parquet.RowGroup{},
 		createdBy:    "parquet-go",
@@ -102,10 +104,16 @@ func WithMaxRowGroupSize(size int64) FileWriterOption {
 	}
 }
 
+func WithMaxPageSize(size int64) FileWriterOption {
+	return func(fw *FileWriter) {
+		fw.schemaWriter.maxPageSize = size
+	}
+}
+
 // WithSchemaDefinition sets the schema definition to use for this parquet file.
 func WithSchemaDefinition(sd *parquetschema.SchemaDefinition) FileWriterOption {
 	return func(fw *FileWriter) {
-		if err := fw.SetSchemaDefinition(sd); err != nil {
+		if err := fw.schemaWriter.SetSchemaDefinition(sd); err != nil {
 			panic(err)
 		}
 	}
@@ -194,7 +202,7 @@ func (fw *FileWriter) FlushRowGroup(opts ...FlushRowGroupOption) error {
 // FlushRowGroupWithContext writes the current row group to the parquet file.
 func (fw *FileWriter) FlushRowGroupWithContext(ctx context.Context, opts ...FlushRowGroupOption) error {
 	// Write the entire row group
-	if fw.rowGroupNumRecords() == 0 {
+	if fw.schemaWriter.rowGroupNumRecords() == 0 {
 		return errors.New("nothing to write")
 	}
 
@@ -210,7 +218,7 @@ func (fw *FileWriter) FlushRowGroupWithContext(ctx context.Context, opts ...Flus
 		o(h)
 	}
 
-	cc, err := writeRowGroup(ctx, fw.w, fw.SchemaWriter, fw.codec, fw.newPageFunc, h)
+	cc, err := writeRowGroup(ctx, fw.w, fw.schemaWriter, fw.codec, fw.newPageFunc, h)
 	if err != nil {
 		return err
 	}
@@ -226,12 +234,12 @@ func (fw *FileWriter) FlushRowGroupWithContext(ctx context.Context, opts ...Flus
 		Columns:             cc,
 		TotalByteSize:       totalUncompressedSize,
 		TotalCompressedSize: &totalCompressedSize,
-		NumRows:             fw.rowGroupNumRecords(),
+		NumRows:             fw.schemaWriter.rowGroupNumRecords(),
 		SortingColumns:      nil,
 	})
-	fw.totalNumRecords += fw.rowGroupNumRecords()
+	fw.totalNumRecords += fw.schemaWriter.rowGroupNumRecords()
 	// flush the schema
-	fw.SchemaWriter.resetData()
+	fw.schemaWriter.resetData()
 
 	return nil
 }
@@ -239,11 +247,11 @@ func (fw *FileWriter) FlushRowGroupWithContext(ctx context.Context, opts ...Flus
 // AddData adds a new record to the current row group and flushes it if auto-flush is enabled and the size
 // is equal to or greater than the configured maximum row group size.
 func (fw *FileWriter) AddData(m map[string]interface{}) error {
-	if err := fw.SchemaWriter.AddData(m); err != nil {
+	if err := fw.schemaWriter.AddData(m); err != nil {
 		return err
 	}
 
-	if fw.rowGroupFlushSize > 0 && fw.SchemaWriter.DataSize() >= fw.rowGroupFlushSize {
+	if fw.rowGroupFlushSize > 0 && fw.schemaWriter.DataSize() >= fw.rowGroupFlushSize {
 		return fw.FlushRowGroup()
 	}
 
@@ -265,7 +273,7 @@ func (fw *FileWriter) Close(opts ...FlushRowGroupOption) error {
 // provided a file as io.Writer when creating the FileWriter, you still need
 // to Close that file handle separately.
 func (fw *FileWriter) CloseWithContext(ctx context.Context, opts ...FlushRowGroupOption) error {
-	if len(fw.rowGroups) == 0 || fw.rowGroupNumRecords() > 0 {
+	if len(fw.rowGroups) == 0 || fw.schemaWriter.rowGroupNumRecords() > 0 {
 		if err := fw.FlushRowGroup(opts...); err != nil {
 			return err
 		}
@@ -285,7 +293,7 @@ func (fw *FileWriter) CloseWithContext(ctx context.Context, opts ...FlushRowGrou
 	}
 	meta := &parquet.FileMetaData{
 		Version:          fw.version,
-		Schema:           fw.getSchemaArray(),
+		Schema:           fw.schemaWriter.getSchemaArray(),
 		NumRows:          fw.totalNumRecords,
 		RowGroups:        fw.rowGroups,
 		KeyValueMetadata: kv,
@@ -310,7 +318,7 @@ func (fw *FileWriter) CloseWithContext(ctx context.Context, opts ...FlushRowGrou
 // a compression format other than UNCOMPRESSED, the final size will most likely be smaller and will dpeend on how well
 // your data can be compressed.
 func (fw *FileWriter) CurrentRowGroupSize() int64 {
-	return fw.SchemaWriter.DataSize()
+	return fw.schemaWriter.DataSize()
 }
 
 // CurrentFileSize returns the amount of data written to the file so far. This does not include data that is in the
@@ -318,4 +326,12 @@ func (fw *FileWriter) CurrentRowGroupSize() int64 {
 // footer is appended to the file upon closing.
 func (fw *FileWriter) CurrentFileSize() int64 {
 	return fw.w.Pos()
+}
+
+func (fw *FileWriter) AddColumn(path string, col *Column) error {
+	return fw.schemaWriter.AddColumn(path, col)
+}
+
+func (fw *FileWriter) AddGroup(path string, rep parquet.FieldRepetitionType) error {
+	return fw.schemaWriter.AddGroup(path, rep)
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -24,7 +24,7 @@ type pageWriter interface {
 	write(ctx context.Context, w io.Writer) (int, int, error)
 }
 
-type newDataPageFunc func(useDict bool) pageWriter
+type newDataPageFunc func(useDict bool, dictValues []interface{}, page *dataPage) pageWriter
 
 type valuesDecoder interface {
 	init(io.Reader) error

--- a/page_dict.go
+++ b/page_dict.go
@@ -52,6 +52,7 @@ func (dp *dictPageReader) read(r io.Reader, ph *parquet.PageHeader, codec parque
 		dp.values = make([]interface{}, 0, dp.numValues)
 	}
 	dp.values = dp.values[:int(dp.numValues)]
+
 	if err := dp.enc.init(reader); err != nil {
 		return err
 	}

--- a/page_v1.go
+++ b/page_v1.go
@@ -171,7 +171,9 @@ func (dp *dataPageWriterV1) write(ctx context.Context, w io.Writer) (int, int, e
 		return 0, 0, err
 	}
 
-	err = encodeValue(dataBuf, encoder, dp.col.data.values.assemble())
+	assembledValues := dp.col.data.values.assemble()
+
+	err = encodeValue(dataBuf, encoder, assembledValues)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/readwrite_test.go
+++ b/readwrite_test.go
@@ -20,7 +20,7 @@ import (
 func TestWriteThenReadFile(t *testing.T) {
 	ctx := context.Background()
 
-	testFunc := func(opts ...FileWriterOption) {
+	testFunc := func(t *testing.T, opts ...FileWriterOption) {
 		_ = os.Mkdir("files", 0755)
 
 		wf, err := os.OpenFile("files/test1.parquet", os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
@@ -62,7 +62,7 @@ func TestWriteThenReadFile(t *testing.T) {
 		require.NoError(t, err, "creating file reader failed")
 
 		cols := r.Columns()
-		require.Len(t, cols, 2, fmt.Sprintf("expected 2 columns, got %d instead", len(cols)))
+		require.Len(t, cols, 2, "got %d column", len(cols))
 		require.Equal(t, "foo", cols[0].Name())
 		require.Equal(t, "foo", cols[0].FlatName())
 		require.Equal(t, "bar", cols[1].Name())
@@ -78,8 +78,12 @@ func TestWriteThenReadFile(t *testing.T) {
 		}
 	}
 
-	testFunc(WithCompressionCodec(parquet.CompressionCodec_SNAPPY), WithCreator("parquet-go-unittest"))
-	testFunc(WithCompressionCodec(parquet.CompressionCodec_SNAPPY), WithCreator("parquet-go-unittest"), WithDataPageV2())
+	t.Run("datapagev1", func(t *testing.T) {
+		testFunc(t, WithCompressionCodec(parquet.CompressionCodec_SNAPPY), WithCreator("parquet-go-unittest"))
+	})
+	t.Run("datapagev2", func(t *testing.T) {
+		testFunc(t, WithCompressionCodec(parquet.CompressionCodec_SNAPPY), WithCreator("parquet-go-unittest"), WithDataPageV2())
+	})
 }
 
 func TestWriteThenReadFileRepeated(t *testing.T) {

--- a/schema_test.go
+++ b/schema_test.go
@@ -84,10 +84,11 @@ func TestColumnSize(t *testing.T) {
 		arr, size := sf.Generate(rand.Intn(1000) + 1)
 		sf.Col.reset(parquet.FieldRepetitionType_REQUIRED, 0, 0)
 		for i := range arr {
-			err := sf.Col.add(&schema{newPageFunc: newDataPageV1Writer}, &Column{}, arr[i], 0, 0, 0)
+			err := sf.Col.add(arr[i], 0, 0, 0)
 			require.NoError(t, err)
 		}
-		require.Equal(t, size, sf.Col.values.size)
+		_, dataSize := sf.Col.values.sizes()
+		require.Equal(t, size, dataSize)
 	}
 }
 

--- a/schema_test.go
+++ b/schema_test.go
@@ -84,7 +84,7 @@ func TestColumnSize(t *testing.T) {
 		arr, size := sf.Generate(rand.Intn(1000) + 1)
 		sf.Col.reset(parquet.FieldRepetitionType_REQUIRED, 0, 0)
 		for i := range arr {
-			err := sf.Col.add(arr[i], 0, 0, 0)
+			err := sf.Col.add(&schema{newPageFunc: newDataPageV1Writer}, &Column{}, arr[i], 0, 0, 0)
 			require.NoError(t, err)
 		}
 		require.Equal(t, size, sf.Col.values.size)

--- a/type_dict_test.go
+++ b/type_dict_test.go
@@ -9,8 +9,8 @@ import (
 func TestDictStore(t *testing.T) {
 	d := dictStore{}
 	d.init()
-	require.Equal(t, d.size, int64(0))
-	require.Equal(t, d.valueSize, int64(0))
+	require.Equal(t, d.allValuesSize, int64(0))
+	require.Equal(t, d.uniqueValuesSize, int64(0))
 
 	d.addValue(int32(1), 4)
 	d.addValue(int32(2), 4)
@@ -20,14 +20,14 @@ func TestDictStore(t *testing.T) {
 	d.addValue(int32(2), 4)
 	d.addValue(int32(3), 4)
 	d.addValue(int32(4), 4)
-	require.Equal(t, d.size, int64(32))
-	require.Equal(t, d.valueSize, int64(16))
+	require.Equal(t, d.allValuesSize, int64(32))
+	require.Equal(t, d.uniqueValuesSize, int64(16))
 	d.addValue(nil, 4)
-	require.Equal(t, d.size, int64(32))
+	require.Equal(t, d.allValuesSize, int64(32))
 
 	d.init()
-	require.Equal(t, d.size, int64(0))
-	require.Equal(t, d.valueSize, int64(0))
+	require.Equal(t, d.allValuesSize, int64(0))
+	require.Equal(t, d.uniqueValuesSize, int64(0))
 }
 
 func TestFuzzCrashDictDecoderDecodeValues(t *testing.T) {


### PR DESCRIPTION
This PR changes the reading and writing of data pages to improve memory usage.

On the read side, it changes reading of data pages to happen lazily, i.e. only when all values of a data page have been read, the next page is loaded into memory.

On the write side, it adds support for parquet-go to be able to write multiple pages per column chunk. The targeted data page size can be configured but is only based on rough estimates. Previously, parquet-go only supported writing a single page per column chunk, defeating the advantage of lazy data page loading on the read side in case we're consuming files that were previously written by parquet-go. Implementing this required extensive changes to how dictionaries were encoded.