### PR TITLE
Add support for data page statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Updated to parquet-format 2.9.0.
+- Added support for page data statistics.
 
 ## [v0.9.0] - 2022-02-10
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ unmarshalling.
 | Byte Stream Split                        | No   | No   |
 | Data page V1                             | Yes  | Yes  |
 | Data page V2                             | Yes  | Yes  |
-| Statistics in page meta data             | No   | No   |
+| Statistics in page meta data             | No   | Yes  | Page meta data is generally not made available to users and not used by parquet-go.
 | Index Pages                              | No   | No   |
 | Dictionary Pages                         | Yes  | Yes  |
 | Encryption                               | No   | No   |

--- a/chunk_writer.go
+++ b/chunk_writer.go
@@ -295,8 +295,8 @@ func writeChunk(ctx context.Context, w writePos, sch *schema, col *Column, codec
 	distinctCount := int64(len(dictValues))
 
 	stats := &parquet.Statistics{
-		MinValue:      col.data.stats().minValue(),
-		MaxValue:      col.data.stats().maxValue(),
+		MinValue:      col.data.getStats().minValue(),
+		MaxValue:      col.data.getStats().maxValue(),
 		NullCount:     &nullValues,
 		DistinctCount: &distinctCount,
 	}

--- a/data_store.go
+++ b/data_store.go
@@ -169,8 +169,8 @@ func (cs *ColumnStore) flushPage(sch *schema, force bool) error {
 		stats: &parquet.Statistics{
 			NullCount:     int64Ptr(int64(cs.values.nullValueCount())),
 			DistinctCount: int64Ptr(cs.values.distinctValueCount()),
-			MaxValue:      cs.pageStats().maxValue(),
-			MinValue:      cs.pageStats().minValue(),
+			MaxValue:      cs.getPageStats().maxValue(),
+			MinValue:      cs.getPageStats().minValue(),
 		},
 	})
 
@@ -226,7 +226,7 @@ func (cs *ColumnStore) resetData() {
 	cs.rLevels.reset(rLevelBitWidth)
 	cs.dLevels.reset(dLevelBitWidth)
 
-	cs.pageStats().reset()
+	cs.getPageStats().reset()
 }
 
 func (cs *ColumnStore) readNextPage() error {
@@ -339,14 +339,14 @@ func getValuesStore(typ *parquet.SchemaElement) (*ColumnStore, error) {
 		return newPlainStore(&byteArrayStore{ColumnParameters: params}), nil
 
 	case parquet.Type_FLOAT:
-		return newPlainStore(&floatStore{ColumnParameters: params, st: newFloatStats(), pagest: newFloatStats()}), nil
+		return newPlainStore(&floatStore{ColumnParameters: params, stats: newFloatStats(), pageStats: newFloatStats()}), nil
 	case parquet.Type_DOUBLE:
-		return newPlainStore(&doubleStore{ColumnParameters: params, st: newDoubleStats(), pagest: newDoubleStats()}), nil
+		return newPlainStore(&doubleStore{ColumnParameters: params, stats: newDoubleStats(), pageStats: newDoubleStats()}), nil
 
 	case parquet.Type_INT32:
-		return newPlainStore(&int32Store{ColumnParameters: params, st: newInt32Stats(), pagest: newInt32Stats()}), nil
+		return newPlainStore(&int32Store{ColumnParameters: params, stats: newInt32Stats(), pageStats: newInt32Stats()}), nil
 	case parquet.Type_INT64:
-		return newPlainStore(&int64Store{ColumnParameters: params, st: newInt64Stats(), pagest: newInt64Stats()}), nil
+		return newPlainStore(&int64Store{ColumnParameters: params, stats: newInt64Stats(), pageStats: newInt64Stats()}), nil
 	case parquet.Type_INT96:
 		store := &int96Store{}
 		store.ColumnParameters = params
@@ -374,7 +374,7 @@ func NewInt32Store(enc parquet.Encoding, useDict bool, params *ColumnParameters)
 	default:
 		return nil, errors.Errorf("encoding %q is not supported on this type", enc)
 	}
-	return newStore(&int32Store{ColumnParameters: params, st: newInt32Stats(), pagest: newInt32Stats()}, enc, useDict), nil
+	return newStore(&int32Store{ColumnParameters: params, stats: newInt32Stats(), pageStats: newInt32Stats()}, enc, useDict), nil
 }
 
 // NewInt64Store creates a new column store to store int64 values. If useDict is true,
@@ -385,7 +385,7 @@ func NewInt64Store(enc parquet.Encoding, useDict bool, params *ColumnParameters)
 	default:
 		return nil, errors.Errorf("encoding %q is not supported on this type", enc)
 	}
-	return newStore(&int64Store{ColumnParameters: params, st: newInt64Stats(), pagest: newInt64Stats()}, enc, useDict), nil
+	return newStore(&int64Store{ColumnParameters: params, stats: newInt64Stats(), pageStats: newInt64Stats()}, enc, useDict), nil
 }
 
 // NewInt96Store creates a new column store to store int96 values. If useDict is true,
@@ -409,7 +409,7 @@ func NewFloatStore(enc parquet.Encoding, useDict bool, params *ColumnParameters)
 	default:
 		return nil, errors.Errorf("encoding %q is not supported on this type", enc)
 	}
-	return newStore(&floatStore{ColumnParameters: params, st: newFloatStats(), pagest: newFloatStats()}, enc, useDict), nil
+	return newStore(&floatStore{ColumnParameters: params, stats: newFloatStats(), pageStats: newFloatStats()}, enc, useDict), nil
 }
 
 // NewDoubleStore creates a new column store to store double (float64) values. If useDict is true,
@@ -420,7 +420,7 @@ func NewDoubleStore(enc parquet.Encoding, useDict bool, params *ColumnParameters
 	default:
 		return nil, errors.Errorf("encoding %q is not supported on this type", enc)
 	}
-	return newStore(&doubleStore{ColumnParameters: params, st: newDoubleStats(), pagest: newDoubleStats()}, enc, useDict), nil
+	return newStore(&doubleStore{ColumnParameters: params, stats: newDoubleStats(), pageStats: newDoubleStats()}, enc, useDict), nil
 }
 
 // NewByteArrayStore creates a new column store to store byte arrays. If useDict is true,

--- a/data_store_test.go
+++ b/data_store_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func newIntStore() *ColumnStore {
-	d := newStore(&int32Store{ColumnParameters: &ColumnParameters{}}, parquet.Encoding_PLAIN, false)
+	d := newStore(&int32Store{ColumnParameters: &ColumnParameters{}, st: newInt32Stats(), pagest: newInt32Stats()}, parquet.Encoding_PLAIN, false)
 	return d
 }
 

--- a/data_store_test.go
+++ b/data_store_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func newIntStore() *ColumnStore {
-	d := newStore(&int32Store{ColumnParameters: &ColumnParameters{}, st: newInt32Stats(), pagest: newInt32Stats()}, parquet.Encoding_PLAIN, false)
+	d := newStore(&int32Store{ColumnParameters: &ColumnParameters{}, stats: newInt32Stats(), pageStats: newInt32Stats()}, parquet.Encoding_PLAIN, false)
 	return d
 }
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -68,8 +68,8 @@ type typedColumnStore interface {
 	parquetColumn
 	reset(repetitionType parquet.FieldRepetitionType)
 
-	stats() minMaxValues
-	pageStats() minMaxValues
+	getStats() minMaxValues
+	getPageStats() minMaxValues
 
 	// Should extract the value, turn it into an array and check for min and max on all values in this
 	getValues(v interface{}) ([]interface{}, error)

--- a/interfaces.go
+++ b/interfaces.go
@@ -58,12 +58,18 @@ type parquetColumn interface {
 	params() *ColumnParameters
 }
 
+type minMaxValues interface {
+	maxValue() []byte
+	minValue() []byte
+	reset()
+}
+
 type typedColumnStore interface {
 	parquetColumn
 	reset(repetitionType parquet.FieldRepetitionType)
-	// Min and Max in parquet byte
-	maxValue() []byte
-	minValue() []byte
+
+	stats() minMaxValues
+	pageStats() minMaxValues
 
 	// Should extract the value, turn it into an array and check for min and max on all values in this
 	getValues(v interface{}) ([]interface{}, error)

--- a/readwrite_test.go
+++ b/readwrite_test.go
@@ -20,10 +20,12 @@ import (
 func TestWriteThenReadFile(t *testing.T) {
 	ctx := context.Background()
 
-	testFunc := func(t *testing.T, opts ...FileWriterOption) {
+	testFunc := func(t *testing.T, name string, opts ...FileWriterOption) {
 		_ = os.Mkdir("files", 0755)
 
-		wf, err := os.OpenFile("files/test1.parquet", os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+		filename := "files/test1_" + name + ".parquet"
+
+		wf, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 		require.NoError(t, err, "creating file failed")
 
 		w := NewFileWriter(wf, opts...)
@@ -54,7 +56,7 @@ func TestWriteThenReadFile(t *testing.T) {
 
 		require.NoError(t, wf.Close())
 
-		rf, err := os.Open("files/test1.parquet")
+		rf, err := os.Open(filename)
 		require.NoError(t, err, "opening file failed")
 		defer rf.Close()
 
@@ -79,10 +81,10 @@ func TestWriteThenReadFile(t *testing.T) {
 	}
 
 	t.Run("datapagev1", func(t *testing.T) {
-		testFunc(t, WithCompressionCodec(parquet.CompressionCodec_SNAPPY), WithCreator("parquet-go-unittest"))
+		testFunc(t, "datapagev1", WithCompressionCodec(parquet.CompressionCodec_SNAPPY), WithCreator("parquet-go-unittest"))
 	})
 	t.Run("datapagev2", func(t *testing.T) {
-		testFunc(t, WithCompressionCodec(parquet.CompressionCodec_SNAPPY), WithCreator("parquet-go-unittest"), WithDataPageV2())
+		testFunc(t, "datapagev2", WithCompressionCodec(parquet.CompressionCodec_SNAPPY), WithCreator("parquet-go-unittest"), WithDataPageV2())
 	})
 }
 

--- a/schema.go
+++ b/schema.go
@@ -744,7 +744,7 @@ func (r *schema) recursiveAddColumnNil(c []*Column, defLvl, maxRepLvl uint16, re
 func (r *schema) recursiveFlushPages(c []*Column) error {
 	for i := range c {
 		if c[i].data != nil {
-			if err := c[i].data.flushPage(false); err != nil {
+			if err := c[i].data.flushPage(r, false); err != nil {
 				return err
 			}
 		}

--- a/stats.go
+++ b/stats.go
@@ -19,24 +19,24 @@ func (s *nilStats) maxValue() []byte {
 func (s *nilStats) reset() {
 }
 
-type stats struct {
+type statistics struct {
 	min []byte
 	max []byte
 }
 
-func (s *stats) minValue() []byte {
+func (s *statistics) minValue() []byte {
 	return s.min
 }
 
-func (s *stats) maxValue() []byte {
+func (s *statistics) maxValue() []byte {
 	return s.max
 }
 
-func (s *stats) reset() {
+func (s *statistics) reset() {
 	s.min, s.max = nil, nil
 }
 
-func (s *stats) setMinMax(j []byte) {
+func (s *statistics) setMinMax(j []byte) {
 	if s.max == nil || s.min == nil {
 		s.min = j
 		s.max = j

--- a/stats.go
+++ b/stats.go
@@ -1,0 +1,224 @@
+package goparquet
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+)
+
+type nilStats struct{}
+
+func (s *nilStats) minValue() []byte {
+	return nil
+}
+
+func (s *nilStats) maxValue() []byte {
+	return nil
+}
+
+func (s *nilStats) reset() {
+}
+
+type stats struct {
+	min []byte
+	max []byte
+}
+
+func (s *stats) minValue() []byte {
+	return s.min
+}
+
+func (s *stats) maxValue() []byte {
+	return s.max
+}
+
+func (s *stats) reset() {
+	s.min, s.max = nil, nil
+}
+
+func (s *stats) setMinMax(j []byte) {
+	if s.max == nil || s.min == nil {
+		s.min = j
+		s.max = j
+		return
+	}
+
+	if bytes.Compare(j, s.min) < 0 {
+		s.min = j
+	}
+	if bytes.Compare(j, s.max) > 0 {
+		s.max = j
+	}
+}
+
+type floatStats struct {
+	min float32
+	max float32
+}
+
+func newFloatStats() *floatStats {
+	s := &floatStats{}
+	s.reset()
+	return s
+}
+
+func (s *floatStats) reset() {
+	s.min = math.MaxFloat32
+	s.max = -math.MaxFloat32
+}
+
+func (s *floatStats) minValue() []byte {
+	if s.min == math.MaxFloat32 {
+		return nil
+	}
+	ret := make([]byte, 4)
+	binary.LittleEndian.PutUint32(ret, math.Float32bits(s.min))
+	return ret
+}
+
+func (s *floatStats) maxValue() []byte {
+	if s.max == -math.MaxFloat32 {
+		return nil
+	}
+	ret := make([]byte, 4)
+	binary.LittleEndian.PutUint32(ret, math.Float32bits(s.max))
+	return ret
+}
+
+func (s *floatStats) setMinMax(j float32) {
+	if j < s.min {
+		s.min = j
+	}
+	if j > s.max {
+		s.max = j
+	}
+}
+
+type doubleStats struct {
+	min float64
+	max float64
+}
+
+func newDoubleStats() *doubleStats {
+	s := &doubleStats{}
+	s.reset()
+	return s
+}
+
+func (s *doubleStats) reset() {
+	s.min = math.MaxFloat64
+	s.max = -math.MaxFloat64
+}
+
+func (s *doubleStats) minValue() []byte {
+	if s.min == math.MaxFloat64 {
+		return nil
+	}
+	ret := make([]byte, 8)
+	binary.LittleEndian.PutUint64(ret, math.Float64bits(s.min))
+	return ret
+}
+
+func (s *doubleStats) maxValue() []byte {
+	if s.max == -math.MaxFloat64 {
+		return nil
+	}
+	ret := make([]byte, 8)
+	binary.LittleEndian.PutUint64(ret, math.Float64bits(s.max))
+	return ret
+}
+
+func (s *doubleStats) setMinMax(j float64) {
+	if j < s.min {
+		s.min = j
+	}
+	if j > s.max {
+		s.max = j
+	}
+}
+
+type int32Stats struct {
+	min int32
+	max int32
+}
+
+func newInt32Stats() *int32Stats {
+	s := &int32Stats{}
+	s.reset()
+	return s
+}
+
+func (s *int32Stats) reset() {
+	s.min = math.MaxInt32
+	s.max = math.MinInt32
+}
+
+func (s *int32Stats) minValue() []byte {
+	if s.min == math.MaxInt32 {
+		return nil
+	}
+	ret := make([]byte, 4)
+	binary.LittleEndian.PutUint32(ret, uint32(s.min))
+	return ret
+}
+
+func (s *int32Stats) maxValue() []byte {
+	if s.max == math.MinInt32 {
+		return nil
+	}
+	ret := make([]byte, 4)
+	binary.LittleEndian.PutUint32(ret, uint32(s.max))
+	return ret
+}
+
+func (s *int32Stats) setMinMax(j int32) {
+	if j < s.min {
+		s.min = j
+	}
+	if j > s.max {
+		s.max = j
+	}
+}
+
+type int64Stats struct {
+	min int64
+	max int64
+}
+
+func newInt64Stats() *int64Stats {
+	s := &int64Stats{}
+	s.reset()
+	return s
+}
+
+func (s *int64Stats) reset() {
+	s.min = math.MaxInt64
+	s.max = math.MinInt64
+}
+
+func (s *int64Stats) minValue() []byte {
+	if s.min == math.MaxInt64 {
+		return nil
+	}
+	ret := make([]byte, 8)
+	binary.LittleEndian.PutUint64(ret, uint64(s.min))
+	return ret
+}
+
+func (s *int64Stats) maxValue() []byte {
+	if s.min == math.MinInt64 {
+		return nil
+	}
+	ret := make([]byte, 8)
+	binary.LittleEndian.PutUint64(ret, uint64(s.max))
+	return ret
+}
+
+func (s *int64Stats) setMinMax(j int64) {
+	if j < s.min {
+		s.min = j
+	}
+	if j > s.max {
+		s.max = j
+	}
+}

--- a/type_boolean.go
+++ b/type_boolean.go
@@ -175,11 +175,11 @@ func (b *booleanStore) reset(repetitionType parquet.FieldRepetitionType) {
 	b.repTyp = repetitionType
 }
 
-func (b *booleanStore) stats() minMaxValues {
+func (b *booleanStore) getStats() minMaxValues {
 	return &nilStats{}
 }
 
-func (b *booleanStore) pageStats() minMaxValues {
+func (b *booleanStore) getPageStats() minMaxValues {
 	return &nilStats{}
 }
 

--- a/type_boolean.go
+++ b/type_boolean.go
@@ -175,12 +175,12 @@ func (b *booleanStore) reset(repetitionType parquet.FieldRepetitionType) {
 	b.repTyp = repetitionType
 }
 
-func (b *booleanStore) maxValue() []byte {
-	return nil
+func (b *booleanStore) stats() minMaxValues {
+	return &nilStats{}
 }
 
-func (b *booleanStore) minValue() []byte {
-	return nil
+func (b *booleanStore) pageStats() minMaxValues {
+	return &nilStats{}
 }
 
 func (b *booleanStore) getValues(v interface{}) ([]interface{}, error) {

--- a/type_bytearray.go
+++ b/type_bytearray.go
@@ -292,19 +292,19 @@ func (b *byteArrayDeltaEncoder) Close() error {
 }
 
 type byteArrayStore struct {
-	repTyp parquet.FieldRepetitionType
-	st     stats
-	pagest stats
+	repTyp    parquet.FieldRepetitionType
+	stats     statistics
+	pageStats statistics
 
 	*ColumnParameters
 }
 
-func (is *byteArrayStore) stats() minMaxValues {
-	return &is.st
+func (is *byteArrayStore) getStats() minMaxValues {
+	return &is.stats
 }
 
-func (is *byteArrayStore) pageStats() minMaxValues {
-	return &is.pagest
+func (is *byteArrayStore) getPageStats() minMaxValues {
+	return &is.pageStats
 }
 
 func (is *byteArrayStore) params() *ColumnParameters {
@@ -332,8 +332,8 @@ func (is *byteArrayStore) repetitionType() parquet.FieldRepetitionType {
 func (is *byteArrayStore) reset(repetitionType parquet.FieldRepetitionType) {
 	is.repTyp = repetitionType
 
-	is.st.reset()
-	is.pagest.reset()
+	is.stats.reset()
+	is.pageStats.reset()
 }
 
 func (is *byteArrayStore) setMinMax(j []byte) error {
@@ -345,8 +345,8 @@ func (is *byteArrayStore) setMinMax(j []byte) error {
 		return nil
 	}
 
-	is.st.setMinMax(j)
-	is.pagest.setMinMax(j)
+	is.stats.setMinMax(j)
+	is.pageStats.setMinMax(j)
 
 	return nil
 }

--- a/type_bytearray.go
+++ b/type_bytearray.go
@@ -292,10 +292,19 @@ func (b *byteArrayDeltaEncoder) Close() error {
 }
 
 type byteArrayStore struct {
-	repTyp   parquet.FieldRepetitionType
-	min, max []byte
+	repTyp parquet.FieldRepetitionType
+	st     stats
+	pagest stats
 
 	*ColumnParameters
+}
+
+func (is *byteArrayStore) stats() minMaxValues {
+	return &is.st
+}
+
+func (is *byteArrayStore) pageStats() minMaxValues {
+	return &is.pagest
 }
 
 func (is *byteArrayStore) params() *ColumnParameters {
@@ -322,16 +331,9 @@ func (is *byteArrayStore) repetitionType() parquet.FieldRepetitionType {
 
 func (is *byteArrayStore) reset(repetitionType parquet.FieldRepetitionType) {
 	is.repTyp = repetitionType
-	is.min = nil
-	is.max = nil
-}
 
-func (is *byteArrayStore) maxValue() []byte {
-	return is.max
-}
-
-func (is *byteArrayStore) minValue() []byte {
-	return is.min
+	is.st.reset()
+	is.pagest.reset()
 }
 
 func (is *byteArrayStore) setMinMax(j []byte) error {
@@ -342,18 +344,9 @@ func (is *byteArrayStore) setMinMax(j []byte) error {
 	if j == nil {
 		return nil
 	}
-	if is.max == nil || is.min == nil {
-		is.min = j
-		is.max = j
-		return nil
-	}
 
-	if bytes.Compare(j, is.min) < 0 {
-		is.min = j
-	}
-	if bytes.Compare(j, is.max) > 0 {
-		is.max = j
-	}
+	is.st.setMinMax(j)
+	is.pagest.setMinMax(j)
 
 	return nil
 }

--- a/type_dict.go
+++ b/type_dict.go
@@ -116,6 +116,10 @@ func (d *dictStore) nullValueCount() int32 {
 	return d.nullCount
 }
 
+func (d *dictStore) distinctValueCount() int64 {
+	return int64(len(d.uniqueValues))
+}
+
 func (d *dictStore) sizes() (dictLen int64, noDictLen int64) {
 	return d.uniqueValuesSize + int64(4*len(d.valueList)), d.allValuesSize
 }

--- a/type_double.go
+++ b/type_double.go
@@ -57,18 +57,18 @@ func (d *doublePlainEncoder) encodeValues(values []interface{}) error {
 type doubleStore struct {
 	repTyp parquet.FieldRepetitionType
 
-	st     *doubleStats
-	pagest *doubleStats
+	stats     *doubleStats
+	pageStats *doubleStats
 
 	*ColumnParameters
 }
 
-func (f *doubleStore) stats() minMaxValues {
-	return f.st
+func (f *doubleStore) getStats() minMaxValues {
+	return f.stats
 }
 
-func (f *doubleStore) pageStats() minMaxValues {
-	return f.pagest
+func (f *doubleStore) getPageStats() minMaxValues {
+	return f.pageStats
 }
 
 func (f *doubleStore) params() *ColumnParameters {
@@ -92,13 +92,13 @@ func (f *doubleStore) repetitionType() parquet.FieldRepetitionType {
 
 func (f *doubleStore) reset(rep parquet.FieldRepetitionType) {
 	f.repTyp = rep
-	f.st.reset()
-	f.pagest.reset()
+	f.stats.reset()
+	f.pageStats.reset()
 }
 
 func (f *doubleStore) setMinMax(j float64) {
-	f.st.setMinMax(j)
-	f.pagest.setMinMax(j)
+	f.stats.setMinMax(j)
+	f.pageStats.setMinMax(j)
 }
 
 func (f *doubleStore) getValues(v interface{}) ([]interface{}, error) {

--- a/type_float.go
+++ b/type_float.go
@@ -56,10 +56,20 @@ func (d *floatPlainEncoder) encodeValues(values []interface{}) error {
 }
 
 type floatStore struct {
-	repTyp   parquet.FieldRepetitionType
-	min, max float32
+	repTyp parquet.FieldRepetitionType
+
+	st     *floatStats
+	pagest *floatStats
 
 	*ColumnParameters
+}
+
+func (f *floatStore) stats() minMaxValues {
+	return f.st
+}
+
+func (f *floatStore) pageStats() minMaxValues {
+	return f.pagest
 }
 
 func (f *floatStore) params() *ColumnParameters {
@@ -83,35 +93,13 @@ func (f *floatStore) repetitionType() parquet.FieldRepetitionType {
 
 func (f *floatStore) reset(rep parquet.FieldRepetitionType) {
 	f.repTyp = rep
-	f.min = math.MaxFloat32
-	f.max = -math.MaxFloat32
-}
-
-func (f *floatStore) maxValue() []byte {
-	if f.max == -math.MaxFloat32 {
-		return nil
-	}
-	ret := make([]byte, 4)
-	binary.LittleEndian.PutUint32(ret, math.Float32bits(f.max))
-	return ret
-}
-
-func (f *floatStore) minValue() []byte {
-	if f.min == math.MaxFloat32 {
-		return nil
-	}
-	ret := make([]byte, 4)
-	binary.LittleEndian.PutUint32(ret, math.Float32bits(f.min))
-	return ret
+	f.st.reset()
+	f.pagest.reset()
 }
 
 func (f *floatStore) setMinMax(j float32) {
-	if j < f.min {
-		f.min = j
-	}
-	if j > f.max {
-		f.max = j
-	}
+	f.st.setMinMax(j)
+	f.pagest.setMinMax(j)
 }
 
 func (f *floatStore) getValues(v interface{}) ([]interface{}, error) {

--- a/type_float.go
+++ b/type_float.go
@@ -58,18 +58,18 @@ func (d *floatPlainEncoder) encodeValues(values []interface{}) error {
 type floatStore struct {
 	repTyp parquet.FieldRepetitionType
 
-	st     *floatStats
-	pagest *floatStats
+	stats     *floatStats
+	pageStats *floatStats
 
 	*ColumnParameters
 }
 
-func (f *floatStore) stats() minMaxValues {
-	return f.st
+func (f *floatStore) getStats() minMaxValues {
+	return f.stats
 }
 
-func (f *floatStore) pageStats() minMaxValues {
-	return f.pagest
+func (f *floatStore) getPageStats() minMaxValues {
+	return f.pageStats
 }
 
 func (f *floatStore) params() *ColumnParameters {
@@ -93,13 +93,13 @@ func (f *floatStore) repetitionType() parquet.FieldRepetitionType {
 
 func (f *floatStore) reset(rep parquet.FieldRepetitionType) {
 	f.repTyp = rep
-	f.st.reset()
-	f.pagest.reset()
+	f.stats.reset()
+	f.pageStats.reset()
 }
 
 func (f *floatStore) setMinMax(j float32) {
-	f.st.setMinMax(j)
-	f.pagest.setMinMax(j)
+	f.stats.setMinMax(j)
+	f.pageStats.setMinMax(j)
 }
 
 func (f *floatStore) getValues(v interface{}) ([]interface{}, error) {

--- a/type_int32.go
+++ b/type_int32.go
@@ -85,18 +85,18 @@ func (d *int32DeltaBPEncoder) encodeValues(values []interface{}) error {
 type int32Store struct {
 	repTyp parquet.FieldRepetitionType
 
-	st     *int32Stats
-	pagest *int32Stats
+	stats     *int32Stats
+	pageStats *int32Stats
 
 	*ColumnParameters
 }
 
-func (is *int32Store) stats() minMaxValues {
-	return is.st
+func (is *int32Store) getStats() minMaxValues {
+	return is.stats
 }
 
-func (is *int32Store) pageStats() minMaxValues {
-	return is.pagest
+func (is *int32Store) getPageStats() minMaxValues {
+	return is.pageStats
 }
 
 func (is *int32Store) params() *ColumnParameters {
@@ -120,13 +120,13 @@ func (is *int32Store) repetitionType() parquet.FieldRepetitionType {
 
 func (is *int32Store) reset(rep parquet.FieldRepetitionType) {
 	is.repTyp = rep
-	is.st.reset()
-	is.pagest.reset()
+	is.stats.reset()
+	is.pageStats.reset()
 }
 
 func (is *int32Store) setMinMax(j int32) {
-	is.st.setMinMax(j)
-	is.pagest.setMinMax(j)
+	is.stats.setMinMax(j)
+	is.pageStats.setMinMax(j)
 }
 
 func (is *int32Store) getValues(v interface{}) ([]interface{}, error) {

--- a/type_int32.go
+++ b/type_int32.go
@@ -3,7 +3,6 @@ package goparquet
 import (
 	"encoding/binary"
 	"io"
-	"math"
 
 	"github.com/fraugster/parquet-go/parquet"
 	"github.com/pkg/errors"
@@ -84,10 +83,20 @@ func (d *int32DeltaBPEncoder) encodeValues(values []interface{}) error {
 }
 
 type int32Store struct {
-	repTyp   parquet.FieldRepetitionType
-	min, max int32
+	repTyp parquet.FieldRepetitionType
+
+	st     *int32Stats
+	pagest *int32Stats
 
 	*ColumnParameters
+}
+
+func (is *int32Store) stats() minMaxValues {
+	return is.st
+}
+
+func (is *int32Store) pageStats() minMaxValues {
+	return is.pagest
 }
 
 func (is *int32Store) params() *ColumnParameters {
@@ -111,35 +120,13 @@ func (is *int32Store) repetitionType() parquet.FieldRepetitionType {
 
 func (is *int32Store) reset(rep parquet.FieldRepetitionType) {
 	is.repTyp = rep
-	is.min = math.MaxInt32
-	is.max = math.MinInt32
-}
-
-func (is *int32Store) maxValue() []byte {
-	if is.max == math.MinInt32 {
-		return nil
-	}
-	ret := make([]byte, 4)
-	binary.LittleEndian.PutUint32(ret, uint32(is.max))
-	return ret
-}
-
-func (is *int32Store) minValue() []byte {
-	if is.min == math.MaxInt32 {
-		return nil
-	}
-	ret := make([]byte, 4)
-	binary.LittleEndian.PutUint32(ret, uint32(is.min))
-	return ret
+	is.st.reset()
+	is.pagest.reset()
 }
 
 func (is *int32Store) setMinMax(j int32) {
-	if j < is.min {
-		is.min = j
-	}
-	if j > is.max {
-		is.max = j
-	}
+	is.st.setMinMax(j)
+	is.pagest.setMinMax(j)
 }
 
 func (is *int32Store) getValues(v interface{}) ([]interface{}, error) {

--- a/type_int64.go
+++ b/type_int64.go
@@ -85,18 +85,18 @@ func (d *int64DeltaBPEncoder) encodeValues(values []interface{}) error {
 type int64Store struct {
 	repTyp parquet.FieldRepetitionType
 
-	st     *int64Stats
-	pagest *int64Stats
+	stats     *int64Stats
+	pageStats *int64Stats
 
 	*ColumnParameters
 }
 
-func (is *int64Store) stats() minMaxValues {
-	return is.st
+func (is *int64Store) getStats() minMaxValues {
+	return is.stats
 }
 
-func (is *int64Store) pageStats() minMaxValues {
-	return is.pagest
+func (is *int64Store) getPageStats() minMaxValues {
+	return is.pageStats
 }
 
 func (is *int64Store) params() *ColumnParameters {
@@ -120,13 +120,13 @@ func (is *int64Store) repetitionType() parquet.FieldRepetitionType {
 
 func (is *int64Store) reset(rep parquet.FieldRepetitionType) {
 	is.repTyp = rep
-	is.st.reset()
-	is.pagest.reset()
+	is.stats.reset()
+	is.pageStats.reset()
 }
 
 func (is *int64Store) setMinMax(j int64) {
-	is.st.setMinMax(j)
-	is.pagest.setMinMax(j)
+	is.stats.setMinMax(j)
+	is.pageStats.setMinMax(j)
 }
 
 func (is *int64Store) getValues(v interface{}) ([]interface{}, error) {

--- a/type_int64.go
+++ b/type_int64.go
@@ -3,7 +3,6 @@ package goparquet
 import (
 	"encoding/binary"
 	"io"
-	"math"
 
 	"github.com/fraugster/parquet-go/parquet"
 	"github.com/pkg/errors"
@@ -84,10 +83,20 @@ func (d *int64DeltaBPEncoder) encodeValues(values []interface{}) error {
 }
 
 type int64Store struct {
-	repTyp   parquet.FieldRepetitionType
-	min, max int64
+	repTyp parquet.FieldRepetitionType
+
+	st     *int64Stats
+	pagest *int64Stats
 
 	*ColumnParameters
+}
+
+func (is *int64Store) stats() minMaxValues {
+	return is.st
+}
+
+func (is *int64Store) pageStats() minMaxValues {
+	return is.pagest
 }
 
 func (is *int64Store) params() *ColumnParameters {
@@ -111,35 +120,13 @@ func (is *int64Store) repetitionType() parquet.FieldRepetitionType {
 
 func (is *int64Store) reset(rep parquet.FieldRepetitionType) {
 	is.repTyp = rep
-	is.min = math.MaxInt64
-	is.max = math.MinInt64
-}
-
-func (is *int64Store) maxValue() []byte {
-	if is.max == math.MinInt64 {
-		return nil
-	}
-	ret := make([]byte, 8)
-	binary.LittleEndian.PutUint64(ret, uint64(is.max))
-	return ret
-}
-
-func (is *int64Store) minValue() []byte {
-	if is.min == math.MaxInt64 {
-		return nil
-	}
-	ret := make([]byte, 8)
-	binary.LittleEndian.PutUint64(ret, uint64(is.min))
-	return ret
+	is.st.reset()
+	is.pagest.reset()
 }
 
 func (is *int64Store) setMinMax(j int64) {
-	if j < is.min {
-		is.min = j
-	}
-	if j > is.max {
-		is.max = j
-	}
+	is.st.setMinMax(j)
+	is.pagest.setMinMax(j)
 }
 
 func (is *int64Store) getValues(v interface{}) ([]interface{}, error) {


### PR DESCRIPTION
This PR adds support for data page statistics. To do this, I moved the recording of minimum and maximum values to a separate set of types, and thus added the ability to distinguish between min/max per row group and min/max per data page. I also added the correct number of rows contained in the data page.