### PR TITLE
Implement read and write support for CRC32 page checksums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated to parquet-format 2.9.0.
 - Added support for page data statistics.
+- Added support for writing per-page CRC32 checksums.
+- Added support for optional CRC32 checksum validation on read.
 
 ## [v0.9.0] - 2022-02-10
 

--- a/chunk_writer.go
+++ b/chunk_writer.go
@@ -227,7 +227,7 @@ func writeChunk(ctx context.Context, w writePos, sch *schema, col *Column, codec
 		if err := dict.init(sch, col, codec, dictValues); err != nil {
 			return nil, err
 		}
-		compSize, unCompSize, err := dict.write(ctx, w)
+		compSize, unCompSize, err := dict.write(ctx, sch, w)
 		if err != nil {
 			return nil, err
 		}
@@ -244,7 +244,7 @@ func writeChunk(ctx context.Context, w writePos, sch *schema, col *Column, codec
 	)
 
 	for _, page := range col.data.dataPages {
-		pw := pageFn(useDict, dictValues, page)
+		pw := pageFn(useDict, dictValues, page, sch.enableCRC)
 
 		if err := pw.init(sch, col, codec); err != nil {
 			return nil, err

--- a/compress.go
+++ b/compress.go
@@ -99,10 +99,9 @@ func decompressBlock(block []byte, method parquet.CompressionCodec) ([]byte, err
 	return c.DecompressBlock(block)
 }
 
-func newBlockReader(in io.Reader, codec parquet.CompressionCodec, compressedSize int32, uncompressedSize int32) (io.Reader, error) {
-	buf, err := ioutil.ReadAll(io.LimitReader(in, int64(compressedSize)))
-	if err != nil {
-		return nil, errors.Wrap(err, "read failed")
+func newBlockReader(buf []byte, codec parquet.CompressionCodec, compressedSize int32, uncompressedSize int32) (io.Reader, error) {
+	if compressedSize < 0 || uncompressedSize < 0 {
+		return nil, errors.New("invalid page data size")
 	}
 
 	if len(buf) != int(compressedSize) {

--- a/file_writer.go
+++ b/file_writer.go
@@ -128,6 +128,12 @@ func WithDataPageV2() FileWriterOption {
 	}
 }
 
+func WithCRC(enableCRC bool) FileWriterOption {
+	return func(fw *FileWriter) {
+		fw.schemaWriter.enableCRC = enableCRC
+	}
+}
+
 // WithWriterContext overrides the default context (which is a context.Background())
 // in the FileWriter with the provided context.Context object.
 func WithWriterContext(ctx context.Context) FileWriterOption {

--- a/interfaces.go
+++ b/interfaces.go
@@ -10,7 +10,7 @@ import (
 // pageReader is an internal interface used only internally to read the pages
 type pageReader interface {
 	init(dDecoder, rDecoder getLevelDecoder, values getValueDecoderFn) error
-	read(r io.Reader, sch *schema, ph *parquet.PageHeader, codec parquet.CompressionCodec) error
+	read(r io.Reader, ph *parquet.PageHeader, codec parquet.CompressionCodec, validateCRC bool) error
 
 	readValues(size int) (values []interface{}, dLevel *packedArray, rLevel *packedArray, err error)
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -10,7 +10,7 @@ import (
 // pageReader is an internal interface used only internally to read the pages
 type pageReader interface {
 	init(dDecoder, rDecoder getLevelDecoder, values getValueDecoderFn) error
-	read(r io.Reader, ph *parquet.PageHeader, codec parquet.CompressionCodec) error
+	read(r io.Reader, sch *schema, ph *parquet.PageHeader, codec parquet.CompressionCodec) error
 
 	readValues(size int) (values []interface{}, dLevel *packedArray, rLevel *packedArray, err error)
 
@@ -24,7 +24,7 @@ type pageWriter interface {
 	write(ctx context.Context, w io.Writer) (int, int, error)
 }
 
-type newDataPageFunc func(useDict bool, dictValues []interface{}, page *dataPage) pageWriter
+type newDataPageFunc func(useDict bool, dictValues []interface{}, page *dataPage, enableCRC bool) pageWriter
 
 type valuesDecoder interface {
 	init(io.Reader) error

--- a/page_dict.go
+++ b/page_dict.go
@@ -12,13 +12,11 @@ import (
 
 // dictionaryPage is not a real data page, so there is no need to implement the page interface
 type dictPageReader struct {
-	ph *parquet.PageHeader
-
-	numValues int32
-	enc       valuesDecoder
-
 	values []interface{}
+	enc    valuesDecoder
+	ph     *parquet.PageHeader
 
+	numValues   int32
 	validateCRC bool
 }
 

--- a/page_v1.go
+++ b/page_v1.go
@@ -125,12 +125,12 @@ func (dp *dataPageReaderV1) read(r io.Reader, sch *schema, ph *parquet.PageHeade
 }
 
 type dataPageWriterV1 struct {
-	col *Column
-
-	codec      parquet.CompressionCodec
-	dictionary bool
 	dictValues []interface{}
+	col        *Column
+	codec      parquet.CompressionCodec
 	page       *dataPage
+
+	dictionary bool
 	enableCRC  bool
 }
 

--- a/page_v2.go
+++ b/page_v2.go
@@ -115,13 +115,13 @@ func (dp *dataPageReaderV2) read(r io.Reader, sch *schema, ph *parquet.PageHeade
 	levelsSize := ph.DataPageHeaderV2.RepetitionLevelsByteLength + ph.DataPageHeaderV2.DefinitionLevelsByteLength
 
 	if ph.DataPageHeaderV2.RepetitionLevelsByteLength > 0 {
-		if err := dp.rDecoder.init(bytes.NewReader(dataPageBlock[:int(ph.DataPageHeaderV2.RepetitionLevelsByteLength)])); err != nil {
+		if err = dp.rDecoder.init(bytes.NewReader(dataPageBlock[:int(ph.DataPageHeaderV2.RepetitionLevelsByteLength)])); err != nil {
 			return errors.Wrapf(err, "read repetition level failed")
 		}
 	}
 
 	if ph.DataPageHeaderV2.DefinitionLevelsByteLength > 0 {
-		if err := dp.dDecoder.init(bytes.NewReader(dataPageBlock[int(ph.DataPageHeaderV2.RepetitionLevelsByteLength):levelsSize])); err != nil {
+		if err = dp.dDecoder.init(bytes.NewReader(dataPageBlock[int(ph.DataPageHeaderV2.RepetitionLevelsByteLength):levelsSize])); err != nil {
 			return errors.Wrapf(err, "read definition level failed")
 		}
 	}
@@ -135,13 +135,13 @@ func (dp *dataPageReaderV2) read(r io.Reader, sch *schema, ph *parquet.PageHeade
 }
 
 type dataPageWriterV2 struct {
-	col    *Column
-	schema SchemaWriter
-
-	codec      parquet.CompressionCodec
-	dictionary bool
 	dictValues []interface{}
+	col        *Column
+	schema     SchemaWriter
+	codec      parquet.CompressionCodec
 	page       *dataPage
+
+	dictionary bool
 	enableCRC  bool
 }
 

--- a/page_v2.go
+++ b/page_v2.go
@@ -211,7 +211,7 @@ func (dp *dataPageWriterV2) write(ctx context.Context, w io.Writer) (int, int, e
 
 	var crc32Checksum *int32
 	if dp.enableCRC {
-		v := int32(crc32.ChecksumIEEE(append(append(rep.Bytes(), def.Bytes()...), comp...))) // TODO: is this correct?
+		v := int32(crc32.ChecksumIEEE(append(append(rep.Bytes(), def.Bytes()...), comp...)))
 		crc32Checksum = &v
 	}
 

--- a/parquet_compatibility_test.go
+++ b/parquet_compatibility_test.go
@@ -61,11 +61,11 @@ func customerMapTest(parquet, csvFl string) func(t *testing.T) {
 			if err := reader.readRowGroup(context.Background()); err == io.EOF {
 				break
 			}
-			count := reader.rowGroupNumRecords()
+			count := reader.schemaReader.rowGroupNumRecords()
 			for i := int64(0); i < count; i++ {
 				rec, err := r.Read()
 				require.NoError(t, err)
-				read, err := reader.getData()
+				read, err := reader.schemaReader.getData()
 				require.NoError(t, err)
 				csvData := toCustomerMap(t, rec)
 				assert.Equal(t, csvData, read)

--- a/readwrite_test.go
+++ b/readwrite_test.go
@@ -23,7 +23,7 @@ func TestWriteThenReadFile(t *testing.T) {
 	testFunc := func(t *testing.T, name string, opts ...FileWriterOption) {
 		_ = os.Mkdir("files", 0755)
 
-		filename := "files/test1_" + name + ".parquet"
+		filename := fmt.Sprintf("files/test1_%s.parquet", name)
 
 		wf, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 		require.NoError(t, err, "creating file failed")
@@ -36,8 +36,12 @@ func TestWriteThenReadFile(t *testing.T) {
 		barStore, err := NewByteArrayStore(parquet.Encoding_PLAIN, true, &ColumnParameters{})
 		require.NoError(t, err, "failed to create barStore")
 
+		bazStore, err := NewInt32Store(parquet.Encoding_PLAIN, true, &ColumnParameters{})
+		require.NoError(t, err, "failed to create bazStore")
+
 		require.NoError(t, w.AddColumn("foo", NewDataColumn(fooStore, parquet.FieldRepetitionType_REQUIRED)))
 		require.NoError(t, w.AddColumn("bar", NewDataColumn(barStore, parquet.FieldRepetitionType_OPTIONAL)))
+		require.NoError(t, w.AddColumn("baz", NewDataColumn(bazStore, parquet.FieldRepetitionType_OPTIONAL)))
 
 		const (
 			numRecords = 10000
@@ -49,7 +53,12 @@ func TestWriteThenReadFile(t *testing.T) {
 				require.NoError(t, w.FlushRowGroup(), "%d. AddData failed", idx)
 			}
 
-			require.NoError(t, w.AddData(map[string]interface{}{"foo": int64(idx), "bar": []byte("value" + fmt.Sprint(idx))}), "%d. AddData failed", idx)
+			data := map[string]interface{}{"foo": int64(idx), "bar": []byte("value" + fmt.Sprint(idx))}
+			if idx%20 != 0 {
+				data["baz"] = int32(idx % 16)
+			}
+
+			require.NoError(t, w.AddData(data), "%d. AddData failed", idx)
 		}
 
 		assert.NoError(t, w.Close(), "Close failed")
@@ -64,15 +73,17 @@ func TestWriteThenReadFile(t *testing.T) {
 		require.NoError(t, err, "creating file reader failed")
 
 		cols := r.Columns()
-		require.Len(t, cols, 2, "got %d column", len(cols))
+		require.Len(t, cols, 3, "got %d column", len(cols))
 		require.Equal(t, "foo", cols[0].Name())
 		require.Equal(t, "foo", cols[0].FlatName())
 		require.Equal(t, "bar", cols[1].Name())
 		require.Equal(t, "bar", cols[1].FlatName())
+		require.Equal(t, "baz", cols[2].Name())
+		require.Equal(t, "baz", cols[2].FlatName())
 		for g := 0; g < r.RowGroupCount(); g++ {
 			require.NoError(t, r.readRowGroup(ctx), "Reading row group failed")
-			for i := 0; i < int(r.rowGroupNumRecords()); i++ {
-				data, err := r.getData()
+			for i := 0; i < int(r.schemaReader.rowGroupNumRecords()); i++ {
+				data, err := r.schemaReader.getData()
 				require.NoError(t, err)
 				_, ok := data["foo"]
 				require.True(t, ok)
@@ -80,12 +91,53 @@ func TestWriteThenReadFile(t *testing.T) {
 		}
 	}
 
-	t.Run("datapagev1", func(t *testing.T) {
-		testFunc(t, "datapagev1", WithCompressionCodec(parquet.CompressionCodec_SNAPPY), WithCreator("parquet-go-unittest"))
-	})
-	t.Run("datapagev2", func(t *testing.T) {
-		testFunc(t, "datapagev2", WithCompressionCodec(parquet.CompressionCodec_SNAPPY), WithCreator("parquet-go-unittest"), WithDataPageV2())
-	})
+	tests := []struct {
+		Name      string
+		WriteOpts []FileWriterOption
+		ReadOpts  []FileReaderOption
+	}{
+		{
+			Name: "datapagev1",
+			WriteOpts: []FileWriterOption{
+				WithCompressionCodec(parquet.CompressionCodec_SNAPPY),
+				WithCreator("parquet-go-unittest"),
+			},
+			ReadOpts: []FileReaderOption{},
+		},
+		{
+			Name: "datapagev2",
+			WriteOpts: []FileWriterOption{
+				WithCompressionCodec(parquet.CompressionCodec_SNAPPY),
+				WithCreator("parquet-go-unittest"), WithDataPageV2(),
+			},
+			ReadOpts: []FileReaderOption{},
+		},
+		{
+			Name: "datapagev1_crc",
+			WriteOpts: []FileWriterOption{
+				WithCompressionCodec(parquet.CompressionCodec_SNAPPY),
+				WithCreator("parquet-go-unittest"),
+				WithCRC(true),
+			},
+			ReadOpts: []FileReaderOption{WithCRC32Validation(true)},
+		},
+		{
+			Name: "datapagev2_crc",
+			WriteOpts: []FileWriterOption{
+				WithCompressionCodec(parquet.CompressionCodec_SNAPPY),
+				WithCreator("parquet-go-unittest"),
+				WithDataPageV2(),
+				WithCRC(true),
+			},
+			ReadOpts: []FileReaderOption{WithCRC32Validation(true)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			testFunc(t, tt.Name, tt.WriteOpts...)
+		})
+	}
 }
 
 func TestWriteThenReadFileRepeated(t *testing.T) {
@@ -128,9 +180,9 @@ func TestWriteThenReadFileRepeated(t *testing.T) {
 	require.NoError(t, err, "creating file reader failed")
 	require.NoError(t, r.readRowGroup(ctx))
 
-	require.Equal(t, int64(len(data)), r.rowGroupNumRecords())
+	require.Equal(t, int64(len(data)), r.schemaReader.rowGroupNumRecords())
 	for i := range data {
-		d, err := r.getData()
+		d, err := r.schemaReader.getData()
 		require.NoError(t, err)
 		require.Equal(t, data[i], d)
 	}
@@ -175,8 +227,8 @@ func TestWriteThenReadFileOptional(t *testing.T) {
 	require.NoError(t, err, "creating file reader failed")
 	require.NoError(t, r.readRowGroup(ctx))
 
-	require.Equal(t, int64(len(data)), r.rowGroupNumRecords())
-	root := r.SchemaReader.(*schema).root
+	require.Equal(t, int64(len(data)), r.schemaReader.rowGroupNumRecords())
+	root := r.schemaReader.root
 	for i := range data {
 		_, ok := data[i]["foo"]
 		rL, dL, b := root.getFirstRDLevel()
@@ -190,7 +242,7 @@ func TestWriteThenReadFileOptional(t *testing.T) {
 			assert.Equal(t, int32(0), dL)
 		}
 
-		get, err := r.getData()
+		get, err := r.schemaReader.getData()
 		require.NoError(t, err)
 		require.Equal(t, data[i], get)
 	}
@@ -238,9 +290,9 @@ func TestWriteThenReadFileNested(t *testing.T) {
 	require.NoError(t, err, "creating file reader failed")
 	require.NoError(t, r.readRowGroup(ctx))
 
-	require.Equal(t, int64(len(data)), r.rowGroupNumRecords())
+	require.Equal(t, int64(len(data)), r.schemaReader.rowGroupNumRecords())
 	for i := range data {
-		d, err := r.getData()
+		d, err := r.schemaReader.getData()
 		require.NoError(t, err)
 		require.Equal(t, data[i], d)
 	}
@@ -312,9 +364,9 @@ func TestWriteThenReadFileNested2(t *testing.T) {
 	require.NoError(t, err, "creating file reader failed")
 	require.NoError(t, r.readRowGroup(ctx))
 
-	require.Equal(t, int64(len(data)), r.rowGroupNumRecords())
+	require.Equal(t, int64(len(data)), r.schemaReader.rowGroupNumRecords())
 	for i := range data {
-		d, err := r.getData()
+		d, err := r.schemaReader.getData()
 		require.NoError(t, err)
 		require.Equal(t, data[i], d)
 	}
@@ -423,9 +475,9 @@ func TestWriteThenReadFileMap(t *testing.T) {
 	require.NoError(t, err, "creating file reader failed")
 	require.NoError(t, r.readRowGroup(ctx))
 
-	require.Equal(t, int64(len(data)), r.rowGroupNumRecords())
+	require.Equal(t, int64(len(data)), r.schemaReader.rowGroupNumRecords())
 	for i := range data {
-		d, err := r.getData()
+		d, err := r.schemaReader.getData()
 		require.NoError(t, err)
 		require.Equal(t, data[i], d)
 	}
@@ -470,9 +522,9 @@ func TestWriteThenReadFileNested3(t *testing.T) {
 	require.NoError(t, err, "creating file reader failed")
 	require.NoError(t, r.readRowGroup(ctx))
 
-	require.Equal(t, int64(len(data)), r.rowGroupNumRecords())
+	require.Equal(t, int64(len(data)), r.schemaReader.rowGroupNumRecords())
 	for i := range data {
-		d, err := r.getData()
+		d, err := r.schemaReader.getData()
 		require.NoError(t, err)
 		require.Equal(t, data[i], d)
 	}
@@ -506,9 +558,9 @@ func TestWriteEmptyDict(t *testing.T) {
 	require.NoError(t, err, "creating file reader failed")
 	require.NoError(t, r.readRowGroup(ctx))
 
-	require.Equal(t, int64(1000), r.rowGroupNumRecords())
+	require.Equal(t, int64(1000), r.schemaReader.rowGroupNumRecords())
 	for i := 0; i < 1000; i++ {
-		d, err := r.getData()
+		d, err := r.schemaReader.getData()
 		require.NoError(t, err)
 		require.Equal(t, map[string]interface{}{}, d)
 	}

--- a/schema.go
+++ b/schema.go
@@ -274,6 +274,9 @@ type schema struct {
 
 	// selected columns in reading. if the size is zero, it means all the columns
 	selectedColumn []string
+
+	enableCRC   bool // if true, CRC32 checksums will be computed for pages upon writing.
+	validateCRC bool // if true, CRC32 checksums will be validated for pages upon reading.
 }
 
 func (r *schema) ensureRoot() {
@@ -1015,7 +1018,7 @@ type SchemaWriter interface {
 	DataSize() int64
 }
 
-func makeSchema(meta *parquet.FileMetaData) (SchemaReader, error) {
+func makeSchema(meta *parquet.FileMetaData, validateCRC bool) (*schema, error) {
 	if len(meta.Schema) < 1 {
 		return nil, errors.New("no schema element found")
 	}
@@ -1037,6 +1040,7 @@ func makeSchema(meta *parquet.FileMetaData) (SchemaReader, error) {
 				FieldID:       meta.Schema[0].FieldID,
 			},
 		},
+		validateCRC: validateCRC,
 	}
 	err := s.readSchema(meta.Schema[1:])
 	if err != nil {


### PR DESCRIPTION
Okay, there's a lot going on in this PR.

First, it adds CRC32 checksum computation when writing pages, both for data pages (V1 and V2) and dictionary pages. From what I've been able to verify through external tools, this seems correct. The checksum computation is optional and needs to be activated with a writer option, so that it doesn't any computational overhead that the user may not want.

Second, it adds CRC checksum validation when reading pages. Again, this is optional to reduce unwanted computational overhead. In order to be able to make this configurable, I had to introduce a new `NewFileReaderWithOptions` function, and added options so that all the optional configuration possible with other `NewFileReader*` functions is available. At the same time, I deprecated `NewFileReaderWithContext` and `NewFileReaderWithMetaData` and turned them into simple wrappers around `NewFileReaderWithOptions`.