### PR TITLE
Improve test coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,11 +12,13 @@ jobs:
       - image: circleci/golang:1.17.2
     environment:
       PARQUET_COMPATIBILITY_REPO_ROOT: /tmp/parquet-compatibility  
+      PARQUET_TESTING_ROOT: /tmp/parquet-testing
     steps:
       - checkout
       - run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.25.0
       - run: golangci-lint run
       - run: git clone https://github.com/Parquet/parquet-compatibility.git ${PARQUET_COMPATIBILITY_REPO_ROOT}
+      - run: git clone https://github.com/apache/parquet-testing.git ${PARQUET_TESTING_ROOT}
       - run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
       - codecov/upload:
           file: coverage.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated to parquet-format 2.9.0.
 - Added support for page data statistics.
+- Improved test coverage.
+- Fixed issue with dictionary encoding where bit width was determined incorrectly.
 
 ## [v0.9.0] - 2022-02-10
 

--- a/chunk_reader.go
+++ b/chunk_reader.go
@@ -38,14 +38,12 @@ func getDictValuesDecoder(typ *parquet.SchemaElement) (valuesDecoder, error) {
 	return nil, errors.Errorf("type %s is not supported for dict value encoder", typ)
 }
 
-func getBooleanValuesDecoder(pageEncoding parquet.Encoding, dictValues []interface{}) (valuesDecoder, error) {
+func getBooleanValuesDecoder(pageEncoding parquet.Encoding) (valuesDecoder, error) {
 	switch pageEncoding {
 	case parquet.Encoding_PLAIN:
 		return &booleanPlainDecoder{}, nil
 	case parquet.Encoding_RLE:
 		return &booleanRLEDecoder{}, nil
-	case parquet.Encoding_RLE_DICTIONARY:
-		return &dictDecoder{uniqueValues: dictValues}, nil
 	default:
 		return nil, errors.Errorf("unsupported encoding %s for boolean", pageEncoding)
 	}
@@ -113,7 +111,7 @@ func getValuesDecoder(pageEncoding parquet.Encoding, typ *parquet.SchemaElement,
 
 	switch *typ.Type {
 	case parquet.Type_BOOLEAN:
-		return getBooleanValuesDecoder(pageEncoding, dictValues)
+		return getBooleanValuesDecoder(pageEncoding)
 
 	case parquet.Type_BYTE_ARRAY:
 		return getByteArrayValuesDecoder(pageEncoding, dictValues)

--- a/chunk_writer.go
+++ b/chunk_writer.go
@@ -10,14 +10,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-func getBooleanValuesEncoder(pageEncoding parquet.Encoding, dictValues []interface{}) (valuesEncoder, error) {
+func getBooleanValuesEncoder(pageEncoding parquet.Encoding) (valuesEncoder, error) {
 	switch pageEncoding {
 	case parquet.Encoding_PLAIN:
 		return &booleanPlainEncoder{}, nil
 	case parquet.Encoding_RLE:
 		return &booleanRLEEncoder{}, nil
-	case parquet.Encoding_RLE_DICTIONARY:
-		return &dictEncoder{dictValues: dictValues}, nil
 	default:
 		return nil, errors.Errorf("unsupported encoding %s for boolean", pageEncoding)
 	}
@@ -97,7 +95,7 @@ func getValuesEncoder(pageEncoding parquet.Encoding, typ *parquet.SchemaElement,
 
 	switch *typ.Type {
 	case parquet.Type_BOOLEAN:
-		return getBooleanValuesEncoder(pageEncoding, dictValues)
+		return getBooleanValuesEncoder(pageEncoding)
 
 	case parquet.Type_BYTE_ARRAY:
 		return getByteArrayValuesEncoder(pageEncoding, dictValues)

--- a/parquet_test.go
+++ b/parquet_test.go
@@ -1,0 +1,67 @@
+package goparquet
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParquetTesting(t *testing.T) {
+	testingRoot := os.Getenv("PARQUET_TESTING_ROOT") // path where https://github.com/apache/parquet-testing has been cloned to.
+	if testingRoot == "" {
+		t.Skip("PARQUET_TESTING_ROOT not set, skipping test")
+	}
+
+	testFiles := []string{
+		"data/alltypes_dictionary.parquet",
+		"data/alltypes_plain.parquet",
+		"data/alltypes_plain.snappy.parquet",
+		"data/binary.parquet",
+		"data/byte_array_decimal.parquet",
+		"data/datapage_v2.snappy.parquet",
+		"data/delta_binary_packed.parquet",
+		//"data/delta_byte_array.parquet",
+		"data/delta_encoding_optional_column.parquet",
+		"data/delta_encoding_required_column.parquet",
+		// "data/dict-page-offset-zero.parquet",
+		"data/fixed_length_decimal.parquet",
+		"data/fixed_length_decimal_legacy.parquet",
+		// "data/hadoop_lz4_compressed.parquet", // LZ4 is currently unsupported out of the box.
+		// "data/hadoop_lz4_compressed_larger.parquet",
+		"data/int32_decimal.parquet",
+		"data/int64_decimal.parquet",
+		"data/list_columns.parquet",
+		"data/nested_lists.snappy.parquet",
+		"data/nested_maps.snappy.parquet",
+		// "data/nested_structs.rust.parquet", // uses ZSTD which is currently unsupported out of the box.
+		"data/nonnullable.impala.parquet",
+		"data/nullable.impala.parquet",
+		"data/nulls.snappy.parquet",
+		"data/repeated_no_annotation.parquet",
+	}
+
+	for _, file := range testFiles {
+		t.Run(file, func(t *testing.T) {
+			fullPath := filepath.Join(testingRoot, file)
+
+			f, err := os.Open(fullPath)
+			require.NoError(t, err)
+			defer f.Close()
+
+			r, err := NewFileReader(f)
+			require.NoError(t, err)
+
+			numRows := r.NumRows()
+
+			t.Logf("%s: got %d rows", file, numRows)
+			t.Logf("%s: schema = %s", file, r.GetSchemaDefinition().String())
+
+			for i := int64(0); i < numRows; i++ {
+				_, err := r.NextRow()
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/readwrite_test.go
+++ b/readwrite_test.go
@@ -929,154 +929,330 @@ func TestWriteThenReadFileUnsetOptional(t *testing.T) {
 	require.Equal(t, io.EOF, err)
 }
 
-func TestReadWriteDeltaLengthByteArrayEncoding(t *testing.T) {
-	var buf bytes.Buffer
-
-	wr := NewFileWriter(&buf)
-
-	bas, err := NewByteArrayStore(parquet.Encoding_DELTA_LENGTH_BYTE_ARRAY, true, &ColumnParameters{})
-	if err != nil {
-		t.Fatal(err)
+func TestReadWriteFixedLenByteArrayEncodings(t *testing.T) {
+	testData := []struct {
+		name    string
+		enc     parquet.Encoding
+		useDict bool
+		input   []byte
+	}{
+		{name: "delta_byte_array_with_dict", enc: parquet.Encoding_DELTA_BYTE_ARRAY, useDict: true, input: []byte{1, 3, 2, 14, 99, 42}},
+		{name: "delta_byte_array_no_dict", enc: parquet.Encoding_DELTA_BYTE_ARRAY, useDict: false, input: []byte{7, 5, 254, 127, 42, 23}},
+		{name: "plain_no_dict", enc: parquet.Encoding_PLAIN, useDict: false, input: []byte{9, 8, 7, 6, 5, 4}},
 	}
 
-	col := NewDataColumn(bas, parquet.FieldRepetitionType_OPTIONAL)
-	if err := wr.AddColumn("name", col); err != nil {
-		t.Fatal(err)
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			wr := NewFileWriter(&buf)
+
+			l := int32(len(tt.input))
+			store, err := NewFixedByteArrayStore(tt.enc, tt.useDict, &ColumnParameters{TypeLength: &l})
+			require.NoError(t, err)
+
+			require.NoError(t, wr.AddColumn("value", NewDataColumn(store, parquet.FieldRepetitionType_REQUIRED)))
+
+			inputRow := map[string]interface{}{"value": tt.input}
+
+			require.NoError(t, wr.AddData(inputRow))
+
+			require.NoError(t, wr.Close())
+
+			rd, err := NewFileReader(bytes.NewReader(buf.Bytes()))
+			require.NoError(t, err)
+
+			outputRow, err := rd.NextRow()
+			require.NoError(t, err)
+
+			require.Equal(t, inputRow, outputRow)
+
+			_, err = rd.NextRow()
+			require.Error(t, err)
+			require.True(t, errors.Is(err, io.EOF))
+		})
+	}
+}
+
+func TestReadWriteByteArrayEncodings(t *testing.T) {
+	testData := []struct {
+		name    string
+		enc     parquet.Encoding
+		useDict bool
+		input   []byte
+	}{
+		{name: "delta_byte_array_with_dict", enc: parquet.Encoding_DELTA_BYTE_ARRAY, useDict: true, input: []byte{1, 3, 2, 14, 99, 42}},
+		{name: "delta_byte_array_no_dict", enc: parquet.Encoding_DELTA_BYTE_ARRAY, useDict: false, input: []byte{7, 5, 254, 127, 42, 23}},
+		{name: "delta_length_byte_array_with_dict", enc: parquet.Encoding_DELTA_LENGTH_BYTE_ARRAY, useDict: true, input: []byte{1, 5, 15, 25, 35, 75}},
+		{name: "delta_length_byte_array_no_dict", enc: parquet.Encoding_DELTA_LENGTH_BYTE_ARRAY, useDict: false, input: []byte{75, 25, 5, 35, 15, 1}},
+		{name: "plain_no_dict", enc: parquet.Encoding_PLAIN, useDict: false, input: []byte{9, 8, 7, 6, 5, 4}},
 	}
 
-	for i := 0; i < 1; i++ {
-		rec := map[string]interface{}{
-			"name": []byte("dan"),
-		}
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			wr := NewFileWriter(&buf)
 
-		if err := wr.AddData(rec); err != nil {
-			t.Fatal(err)
-		}
+			store, err := NewByteArrayStore(tt.enc, tt.useDict, &ColumnParameters{})
+			require.NoError(t, err)
+
+			require.NoError(t, wr.AddColumn("value", NewDataColumn(store, parquet.FieldRepetitionType_REQUIRED)))
+
+			inputRow := map[string]interface{}{"value": tt.input}
+
+			require.NoError(t, wr.AddData(inputRow))
+
+			require.NoError(t, wr.Close())
+
+			rd, err := NewFileReader(bytes.NewReader(buf.Bytes()))
+			require.NoError(t, err)
+
+			outputRow, err := rd.NextRow()
+			require.NoError(t, err)
+
+			require.Equal(t, inputRow, outputRow)
+
+			_, err = rd.NextRow()
+			require.Error(t, err)
+			require.True(t, errors.Is(err, io.EOF))
+		})
+	}
+}
+
+func TestReadWriteInt64Encodings(t *testing.T) {
+	testData := []struct {
+		name    string
+		enc     parquet.Encoding
+		useDict bool
+		input   int64
+	}{
+		{name: "plain_no_dict", enc: parquet.Encoding_PLAIN, useDict: false, input: 87743737636726},
+		{name: "plain_with_dict", enc: parquet.Encoding_PLAIN, useDict: true, input: 42},
+		{name: "delta_binary_packed", enc: parquet.Encoding_DELTA_BINARY_PACKED, useDict: false, input: 6363228832},
 	}
 
-	if err := wr.Close(); err != nil {
-		t.Fatal(err)
-	}
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
 
-	rd, err := NewFileReader(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
+			wr := NewFileWriter(&buf)
 
-	for {
-		row, err := rd.NextRow()
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				break
+			bas, err := NewInt64Store(tt.enc, tt.useDict, &ColumnParameters{})
+			require.NoError(t, err)
+
+			col := NewDataColumn(bas, parquet.FieldRepetitionType_REQUIRED)
+			require.NoError(t, wr.AddColumn("number", col))
+
+			inputRow := map[string]interface{}{
+				"number": tt.input,
 			}
-			t.Fatal(err)
-		}
-		t.Log(row)
+
+			require.NoError(t, wr.AddData(inputRow))
+
+			require.NoError(t, wr.Close())
+
+			rd, err := NewFileReader(bytes.NewReader(buf.Bytes()))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			outputRow, err := rd.NextRow()
+			require.NoError(t, err)
+
+			require.Equal(t, inputRow, outputRow)
+
+			_, err = rd.NextRow()
+			require.True(t, errors.Is(err, io.EOF))
+		})
 	}
 }
 
-func TestReadWriteDeltaBinaryPackedInt32(t *testing.T) {
-	var buf bytes.Buffer
-
-	wr := NewFileWriter(&buf)
-
-	bas, err := NewInt32Store(parquet.Encoding_DELTA_BINARY_PACKED, true, &ColumnParameters{})
-	if err != nil {
-		t.Fatal(err)
+func TestReadWriteInt32Encodings(t *testing.T) {
+	testData := []struct {
+		name    string
+		enc     parquet.Encoding
+		useDict bool
+		input   int32
+	}{
+		{name: "plain_no_dict", enc: parquet.Encoding_PLAIN, useDict: false, input: 3628282},
+		{name: "plain_with_dict", enc: parquet.Encoding_PLAIN, useDict: true, input: 23},
+		{name: "delta_binary_packed", enc: parquet.Encoding_DELTA_BINARY_PACKED, useDict: false, input: 9361082},
 	}
 
-	col := NewDataColumn(bas, parquet.FieldRepetitionType_OPTIONAL)
-	if err := wr.AddColumn("number", col); err != nil {
-		t.Fatal(err)
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+
+			wr := NewFileWriter(&buf)
+
+			bas, err := NewInt32Store(tt.enc, tt.useDict, &ColumnParameters{})
+			require.NoError(t, err)
+
+			col := NewDataColumn(bas, parquet.FieldRepetitionType_REQUIRED)
+			require.NoError(t, wr.AddColumn("number", col))
+
+			inputRow := map[string]interface{}{
+				"number": tt.input,
+			}
+
+			require.NoError(t, wr.AddData(inputRow))
+
+			require.NoError(t, wr.Close())
+
+			rd, err := NewFileReader(bytes.NewReader(buf.Bytes()))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			outputRow, err := rd.NextRow()
+			require.NoError(t, err)
+
+			require.Equal(t, inputRow, outputRow)
+
+			_, err = rd.NextRow()
+			require.True(t, errors.Is(err, io.EOF))
+		})
 	}
-
-	numRecords := 1
-
-	for i := 0; i < numRecords; i++ {
-		rec := map[string]interface{}{
-			"number": int32(42),
-		}
-
-		if err := wr.AddData(rec); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	if err := wr.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	rd, err := NewFileReader(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Logf("Reading data...")
-
-	for i := 0; i < numRecords; i++ {
-		row, err := rd.NextRow()
-		if err != nil {
-			t.Fatalf("got error at record %d of %d: %v", i+1, numRecords, err)
-		}
-		t.Log(row)
-	}
-
-	_, err = rd.NextRow()
-	require.True(t, errors.Is(err, io.EOF))
-
-	t.Logf("Finished")
 }
 
-func TestReadWriteDeltaBinaryPackedInt64(t *testing.T) {
-	var buf bytes.Buffer
-
-	wr := NewFileWriter(&buf)
-
-	bas, err := NewInt64Store(parquet.Encoding_DELTA_BINARY_PACKED, true, &ColumnParameters{})
-	if err != nil {
-		t.Fatal(err)
+func TestReadWriteInt96Encodings(t *testing.T) {
+	testData := []struct {
+		name    string
+		enc     parquet.Encoding
+		useDict bool
+		input   [12]byte
+	}{
+		{name: "plain_no_dict", enc: parquet.Encoding_PLAIN, useDict: false, input: TimeToInt96(time.Date(2020, 3, 16, 14, 30, 0, 0, time.UTC))},
+		{name: "plain_with_dict", enc: parquet.Encoding_PLAIN, useDict: true, input: TimeToInt96(time.Now())},
 	}
 
-	col := NewDataColumn(bas, parquet.FieldRepetitionType_OPTIONAL)
-	if err := wr.AddColumn("number", col); err != nil {
-		t.Fatal(err)
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+
+			wr := NewFileWriter(&buf)
+
+			bas, err := NewInt96Store(tt.enc, tt.useDict, &ColumnParameters{})
+			require.NoError(t, err)
+
+			col := NewDataColumn(bas, parquet.FieldRepetitionType_REQUIRED)
+			require.NoError(t, wr.AddColumn("ts", col))
+
+			inputRow := map[string]interface{}{
+				"ts": tt.input,
+			}
+
+			require.NoError(t, wr.AddData(inputRow))
+
+			require.NoError(t, wr.Close())
+
+			rd, err := NewFileReader(bytes.NewReader(buf.Bytes()))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			outputRow, err := rd.NextRow()
+			require.NoError(t, err)
+
+			require.Equal(t, inputRow, outputRow)
+
+			_, err = rd.NextRow()
+			require.True(t, errors.Is(err, io.EOF))
+		})
+	}
+}
+
+func TestReadWriteFloatEncodings(t *testing.T) {
+	testData := []struct {
+		name    string
+		enc     parquet.Encoding
+		useDict bool
+		input   float32
+	}{
+		{name: "plain_no_dict", enc: parquet.Encoding_PLAIN, useDict: false, input: 1.1111},
+		{name: "plain_with_dict", enc: parquet.Encoding_PLAIN, useDict: true, input: 2.2222},
 	}
 
-	numRecords := 1
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
 
-	for i := 0; i < numRecords; i++ {
-		rec := map[string]interface{}{
-			"number": int64(23),
-		}
+			wr := NewFileWriter(&buf)
 
-		if err := wr.AddData(rec); err != nil {
-			t.Fatal(err)
-		}
+			bas, err := NewFloatStore(tt.enc, tt.useDict, &ColumnParameters{})
+			require.NoError(t, err)
+
+			col := NewDataColumn(bas, parquet.FieldRepetitionType_REQUIRED)
+			require.NoError(t, wr.AddColumn("number", col))
+
+			inputRow := map[string]interface{}{
+				"number": tt.input,
+			}
+
+			require.NoError(t, wr.AddData(inputRow))
+
+			require.NoError(t, wr.Close())
+
+			rd, err := NewFileReader(bytes.NewReader(buf.Bytes()))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			outputRow, err := rd.NextRow()
+			require.NoError(t, err)
+
+			require.Equal(t, inputRow, outputRow)
+
+			_, err = rd.NextRow()
+			require.True(t, errors.Is(err, io.EOF))
+		})
+	}
+}
+
+func TestReadWriteDoubleEncodings(t *testing.T) {
+	testData := []struct {
+		name    string
+		enc     parquet.Encoding
+		useDict bool
+		input   float64
+	}{
+		{name: "plain_no_dict", enc: parquet.Encoding_PLAIN, useDict: false, input: 42.123456},
+		{name: "plain_with_dict", enc: parquet.Encoding_PLAIN, useDict: true, input: 32.98765},
 	}
 
-	if err := wr.Close(); err != nil {
-		t.Fatal(err)
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+
+			wr := NewFileWriter(&buf)
+
+			bas, err := NewDoubleStore(tt.enc, tt.useDict, &ColumnParameters{})
+			require.NoError(t, err)
+
+			col := NewDataColumn(bas, parquet.FieldRepetitionType_REQUIRED)
+			require.NoError(t, wr.AddColumn("number", col))
+
+			inputRow := map[string]interface{}{
+				"number": tt.input,
+			}
+
+			require.NoError(t, wr.AddData(inputRow))
+
+			require.NoError(t, wr.Close())
+
+			rd, err := NewFileReader(bytes.NewReader(buf.Bytes()))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			outputRow, err := rd.NextRow()
+			require.NoError(t, err)
+
+			require.Equal(t, inputRow, outputRow)
+
+			_, err = rd.NextRow()
+			require.True(t, errors.Is(err, io.EOF))
+		})
 	}
-
-	rd, err := NewFileReader(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Logf("Reading data...")
-
-	for i := 0; i < numRecords; i++ {
-		row, err := rd.NextRow()
-		if err != nil {
-			t.Fatalf("got error at record %d of %d: %v", i+1, numRecords, err)
-		}
-		t.Log(row)
-	}
-
-	_, err = rd.NextRow()
-	require.True(t, errors.Is(err, io.EOF))
-
-	t.Logf("Finished")
 }
 
 func TestWriteThenReadMultiplePages(t *testing.T) {

--- a/type_dict.go
+++ b/type_dict.go
@@ -132,7 +132,7 @@ type dictEncoder struct {
 }
 
 func (d *dictEncoder) Close() error {
-	v := len(d.indices)
+	v := len(d.dictValues)
 	bitWidth := bits.Len(uint(v))
 
 	// first write the bitLength in a byte


### PR DESCRIPTION
This PR improves test coverage of bits and pieces of the code that weren't previously covered by the extensive tests.

It also extends compatibility testing by checking the reader implementation against data files from `https://github.com/apache/parquet-testing`.

During the effort to improve test coverage, I also found an issue where the required bit width for dictionary encoding was chosen incorrectly. This issue only seems to appear with small page sizes, and was not an issue in the past because setting the correct maximum page size did not work reliably. After that had been fixed, only then this issue appeared.