### PR TITLE
Add allocation tracking and add option to set maximum amount of memory to aid in protecting against adversarial input

### DIFF
--- a/alloc.go
+++ b/alloc.go
@@ -1,0 +1,76 @@
+package goparquet
+
+import (
+	"fmt"
+	"runtime"
+)
+
+type allocTracker struct {
+	allocs    map[interface{}]uint64
+	totalSize uint64
+	maxSize   uint64
+}
+
+func newAllocTracker(maxSize uint64) *allocTracker {
+	return &allocTracker{
+		allocs:  make(map[interface{}]uint64),
+		maxSize: maxSize,
+	}
+}
+
+func (t *allocTracker) register(obj interface{}, size uint64) {
+	if t == nil {
+		return
+	}
+
+	if _, ok := t.allocs[obj]; ok { // object has already been tracked, no need to add it.
+		return
+	}
+
+	t.allocs[obj] = size
+	t.totalSize += size
+
+	runtime.SetFinalizer(obj, t.finalize)
+
+	if t.maxSize > 0 && t.totalSize > t.maxSize {
+		t.doPanic(t.totalSize)
+	}
+}
+
+func (t *allocTracker) test(size uint64) {
+	if t == nil {
+		return
+	}
+	if t.maxSize > 0 && t.totalSize+size > t.maxSize {
+		t.doPanic(t.totalSize + size)
+	}
+}
+
+func (t *allocTracker) doPanic(totalSize uint64) {
+	if t == nil {
+		return
+	}
+	panic(fmt.Sprintf("memory usage of %d bytes is greater than configured maximum of %d bytes", totalSize, t.maxSize))
+}
+
+func (t *allocTracker) finalize(obj interface{}) {
+	if t == nil {
+		return
+	}
+
+	size, ok := t.allocs[obj]
+	if !ok { // if object hasn't been tracked, do nothing.
+		return
+	}
+
+	// remove size from total size, and unregister from tracker.
+	t.totalSize -= size
+	delete(t.allocs, obj)
+}
+
+func (t *allocTracker) getTotalSize() uint64 {
+	if t == nil {
+		return 0
+	}
+	return t.totalSize
+}

--- a/alloc_test.go
+++ b/alloc_test.go
@@ -1,0 +1,98 @@
+package goparquet
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/fraugster/parquet-go/parquet"
+	"github.com/fraugster/parquet-go/parquetschema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllocTrackerTriggerError(t *testing.T) {
+	var buf bytes.Buffer
+
+	sd, err := parquetschema.ParseSchemaDefinition(`message test {
+		required binary foo (STRING);
+	}`)
+	require.NoError(t, err)
+
+	wr := NewFileWriter(&buf,
+		WithSchemaDefinition(sd),
+		WithMaxRowGroupSize(150*1024*1024),
+		WithMaxPageSize(150*1024*1024),
+		WithCompressionCodec(parquet.CompressionCodec_SNAPPY),
+	)
+	// this should produce ~20 MiB easily compressible data
+	for i := 0; i < 20*1024; i++ {
+		err := wr.AddData(map[string]interface{}{
+			"foo": func() []byte {
+				var data [512]byte
+				data[0] = byte(i % 256)
+				data[1] = byte(i / 256)
+				return []byte(fmt.Sprintf("%x", data[:]))
+			}(),
+		})
+		require.NoError(t, err)
+	}
+	require.NoError(t, wr.FlushRowGroup())
+	require.NoError(t, wr.Close())
+
+	t.Logf("buf size: %d", buf.Len())
+
+	// we set a maximum memory size for that file of 10 MiB, so fully reading the file created earlier should fail.
+	r, err := NewFileReaderWithOptions(bytes.NewReader(buf.Bytes()), WithMaximumMemorySize(10*1024*1024))
+	require.NoError(t, err)
+
+	_, err = r.NextRow()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bytes is greater than configured maximum of 10485760 bytes")
+}
+
+func TestAllocTrackerTriggerNoError(t *testing.T) {
+	var buf bytes.Buffer
+
+	sd, err := parquetschema.ParseSchemaDefinition(`message test {
+		required binary foo (STRING);
+	}`)
+	require.NoError(t, err)
+
+	wr := NewFileWriter(&buf,
+		WithSchemaDefinition(sd),
+		WithMaxPageSize(1024*1024),
+		WithCompressionCodec(parquet.CompressionCodec_SNAPPY),
+	)
+	// this should produce ~20 MiB easily compressible data
+	for i := 0; i < 20*1024; i++ {
+		err := wr.AddData(map[string]interface{}{
+			"foo": func() []byte {
+				var data [512]byte
+				data[0] = byte(i % 256)
+				data[1] = byte(i / 256)
+				return []byte(fmt.Sprintf("%x", data[:]))
+			}(),
+		})
+		require.NoError(t, err)
+	}
+	require.NoError(t, wr.FlushRowGroup())
+	require.NoError(t, wr.Close())
+
+	t.Logf("buf size: %d", buf.Len())
+
+	// we set a maximum memory size for that file of 100 MiB, so fully reading the file created earlier should not fail.
+	r, err := NewFileReaderWithOptions(bytes.NewReader(buf.Bytes()), WithMaximumMemorySize(100*1024*1024))
+	require.NoError(t, err)
+
+	for i := 0; ; i++ {
+		_, err := r.NextRow()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			t.Fatalf("NextRow %d returned error: %v", i, err)
+		}
+	}
+}

--- a/data_store_test.go
+++ b/data_store_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func newIntStore() *ColumnStore {
-	d := newStore(&int32Store{ColumnParameters: &ColumnParameters{}, stats: newInt32Stats(), pageStats: newInt32Stats()}, parquet.Encoding_PLAIN, false)
+	d := newStore(&int32Store{ColumnParameters: &ColumnParameters{}, stats: newInt32Stats(), pageStats: newInt32Stats()}, parquet.Encoding_PLAIN, false, nil)
 	return d
 }
 

--- a/file_writer.go
+++ b/file_writer.go
@@ -52,7 +52,7 @@ func NewFileWriter(w io.Writer, options ...FileWriterOption) *FileWriter {
 		},
 		bw:           bw,
 		version:      1,
-		schemaWriter: &schema{},
+		schemaWriter: &schema{}, // no allocTracker is set here because we're creating a writer. We assume for the moment that writers have enough control over input that they're trusted.
 		kvStore:      make(map[string]string),
 		rowGroups:    []*parquet.RowGroup{},
 		createdBy:    "parquet-go",

--- a/page_dict.go
+++ b/page_dict.go
@@ -19,6 +19,8 @@ type dictPageReader struct {
 
 	numValues   int32
 	validateCRC bool
+
+	alloc *allocTracker
 }
 
 func (dp *dictPageReader) init(dict valuesDecoder) error {
@@ -45,12 +47,12 @@ func (dp *dictPageReader) read(r io.Reader, ph *parquet.PageHeader, codec parque
 
 	dp.ph = ph
 
-	dictPageBlock, err := readPageBlock(r, codec, ph.GetCompressedPageSize(), ph.GetUncompressedPageSize(), dp.validateCRC, ph.Crc)
+	dictPageBlock, err := readPageBlock(r, codec, ph.GetCompressedPageSize(), ph.GetUncompressedPageSize(), dp.validateCRC, ph.Crc, dp.alloc)
 	if err != nil {
 		return err
 	}
 
-	reader, err := newBlockReader(dictPageBlock, codec, ph.GetCompressedPageSize(), ph.GetUncompressedPageSize())
+	reader, err := newBlockReader(dictPageBlock, codec, ph.GetCompressedPageSize(), ph.GetUncompressedPageSize(), dp.alloc)
 	if err != nil {
 		return err
 	}

--- a/page_v1.go
+++ b/page_v1.go
@@ -22,6 +22,8 @@ type dataPageReaderV1 struct {
 	fn                 getValueDecoderFn
 
 	position int
+
+	alloc *allocTracker
 }
 
 func (dp *dataPageReaderV1) numValues() int32 {
@@ -91,12 +93,12 @@ func (dp *dataPageReaderV1) read(r io.Reader, ph *parquet.PageHeader, codec parq
 		return fmt.Errorf("negative NumValues in DATA_PAGE: %d", dp.valuesCount)
 	}
 
-	dataPageBlock, err := readPageBlock(r, codec, ph.GetCompressedPageSize(), ph.GetUncompressedPageSize(), validateCRC, ph.Crc)
+	dataPageBlock, err := readPageBlock(r, codec, ph.GetCompressedPageSize(), ph.GetUncompressedPageSize(), validateCRC, ph.Crc, dp.alloc)
 	if err != nil {
 		return err
 	}
 
-	reader, err := newBlockReader(dataPageBlock, codec, ph.GetCompressedPageSize(), ph.GetUncompressedPageSize())
+	reader, err := newBlockReader(dataPageBlock, codec, ph.GetCompressedPageSize(), ph.GetUncompressedPageSize(), dp.alloc)
 	if err != nil {
 		return err
 	}

--- a/page_v2.go
+++ b/page_v2.go
@@ -20,6 +20,8 @@ type dataPageReaderV2 struct {
 	dDecoder, rDecoder levelDecoder
 	fn                 getValueDecoderFn
 	position           int
+
+	alloc *allocTracker
 }
 
 func (dp *dataPageReaderV2) numValues() int32 {
@@ -101,7 +103,7 @@ func (dp *dataPageReaderV2) read(r io.Reader, ph *parquet.PageHeader, codec parq
 		}
 	}
 
-	dataPageBlock, err := readPageBlock(r, codec, ph.GetCompressedPageSize(), ph.GetUncompressedPageSize(), validateCRC, ph.Crc)
+	dataPageBlock, err := readPageBlock(r, codec, ph.GetCompressedPageSize(), ph.GetUncompressedPageSize(), validateCRC, ph.Crc, dp.alloc)
 	if err != nil {
 		return err
 	}
@@ -120,7 +122,7 @@ func (dp *dataPageReaderV2) read(r io.Reader, ph *parquet.PageHeader, codec parq
 		}
 	}
 
-	reader, err := newBlockReader(dataPageBlock[levelsSize:], codec, ph.GetCompressedPageSize()-levelsSize, ph.GetUncompressedPageSize()-levelsSize)
+	reader, err := newBlockReader(dataPageBlock[levelsSize:], codec, ph.GetCompressedPageSize()-levelsSize, ph.GetUncompressedPageSize()-levelsSize, dp.alloc)
 	if err != nil {
 		return err
 	}

--- a/type_bytearray.go
+++ b/type_bytearray.go
@@ -315,6 +315,13 @@ func (is *byteArrayStore) params() *ColumnParameters {
 }
 
 func (is *byteArrayStore) sizeOf(v interface{}) int {
+	if vv, ok := v.([][]byte); ok {
+		l := 0
+		for _, vvv := range vv {
+			l += len(vvv)
+		}
+		return l
+	}
 	return len(v.([]byte))
 }
 

--- a/type_dict.go
+++ b/type_dict.go
@@ -67,6 +67,8 @@ type dictStore struct {
 	readPos          int
 	nullCount        int32
 	useDict          bool
+
+	alloc *allocTracker
 }
 
 func (d *dictStore) getValues() []interface{} {
@@ -103,6 +105,7 @@ func (d *dictStore) addValue(v interface{}, size int) {
 	}
 	d.allValuesSize += int64(size)
 	d.valueList = append(d.valueList, v)
+	d.alloc.register(v, uint64(size))
 }
 
 func (d *dictStore) getNextValue() (interface{}, error) {

--- a/type_double.go
+++ b/type_double.go
@@ -79,6 +79,9 @@ func (f *doubleStore) params() *ColumnParameters {
 }
 
 func (*doubleStore) sizeOf(v interface{}) int {
+	if vv, ok := v.([]float64); ok {
+		return 8 * len(vv)
+	}
 	return 8
 }
 

--- a/type_float.go
+++ b/type_float.go
@@ -79,6 +79,9 @@ func (f *floatStore) params() *ColumnParameters {
 }
 
 func (*floatStore) sizeOf(v interface{}) int {
+	if vv, ok := v.([]float32); ok {
+		return 4 * len(vv)
+	}
 	return 4
 }
 

--- a/type_int32.go
+++ b/type_int32.go
@@ -107,6 +107,9 @@ func (is *int32Store) params() *ColumnParameters {
 }
 
 func (*int32Store) sizeOf(v interface{}) int {
+	if vv, ok := v.([]int32); ok {
+		return 4 * len(vv)
+	}
 	return 4
 }
 

--- a/type_int64.go
+++ b/type_int64.go
@@ -107,6 +107,9 @@ func (is *int64Store) params() *ColumnParameters {
 }
 
 func (*int64Store) sizeOf(v interface{}) int {
+	if vv, ok := v.([]int64); ok {
+		return 8 * len(vv)
+	}
 	return 8
 }
 

--- a/type_int96.go
+++ b/type_int96.go
@@ -70,6 +70,9 @@ type int96Store struct {
 }
 
 func (*int96Store) sizeOf(v interface{}) int {
+	if vv, ok := v.([][12]byte); ok {
+		return 12 * len(vv)
+	}
 	return 12
 }
 


### PR DESCRIPTION
This PR adds allocation tracking, a simple and slightly hacky way to optionally and approximately track how much memory is allocated and to make parquet-go fail if it detects potentially too much memory used up by reading adversarial input. This feature needs to be explicitly enabled through a new reader option.