### PR TITLE
bug fix: The column path is always override by the last modification

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -681,7 +681,9 @@ func recursiveFix(col *Column, colPath ColumnPath, maxR, maxD uint16, alloc *all
 
 	col.maxR = maxR
 	col.maxD = maxD
-	col.path = append(colPath, col.name)
+	// copy the path
+	col.path = append([]string(nil), colPath...)
+	col.path = append(col.path, col.name)
 	if col.data != nil {
 		col.data.reset(col.rep, col.maxR, col.maxD)
 		return


### PR DESCRIPTION
This PR fixes the issue here: https://github.com/fraugster/parquet-go/issues/98 