### PR TITLE
Do not try to uncompress pages that are not compressed

### DIFF
--- a/compress.go
+++ b/compress.go
@@ -122,7 +122,7 @@ func newBlockReader(buf []byte, codec parquet.CompressionCodec, compressedSize i
 	return bytes.NewReader(res), nil
 }
 
-// RegisterBlockCompressor is a function to to register additional block compressors to the package. By default,
+// RegisterBlockCompressor is a function to register additional block compressors to the package. By default,
 // only UNCOMPRESSED, GZIP and SNAPPY are supported as parquet compression algorithms. The parquet file format
 // supports more compression algorithms, such as LZO, BROTLI, LZ4 and ZSTD. To limit the amount of external dependencies,
 // the number of supported algorithms was reduced to a core set. If you want to use any of the other compression

--- a/deltabp_decoder.go
+++ b/deltabp_decoder.go
@@ -133,6 +133,13 @@ func (d *deltaBitPackDecoder32) next() (int32, error) {
 		if d.position%d.miniBlockValueCount == 0 {
 			// do we need to advance a big block?
 			if d.currentMiniBlock >= d.miniBlockCount {
+				remainingValues := d.valuesCount - d.position
+				if remainingValues == 1 {
+					// Only 1 value left, no deltas to read, just return the last value
+					ret := d.previousValue
+					d.position++
+					return ret, nil
+				}
 				if err := d.readMiniBlockHeader(); err != nil {
 					return 0, err
 				}
@@ -309,6 +316,13 @@ func (d *deltaBitPackDecoder64) next() (int64, error) {
 		if d.position%d.miniBlockValueCount == 0 {
 			// do we need to advance a big block?
 			if d.currentMiniBlock >= d.miniBlockCount {
+				remainingValues := d.valuesCount - d.position
+				if remainingValues == 1 {
+					// Only 1 value left, no deltas to read, just return the last value
+					ret := d.previousValue
+					d.position++
+					return ret, nil
+				}
 				if err := d.readMiniBlockHeader(); err != nil {
 					return 0, err
 				}

--- a/deltabp_decoder.go
+++ b/deltabp_decoder.go
@@ -41,8 +41,11 @@ func (d *deltaBitPackDecoder32) init(r io.Reader) error {
 		return err
 	}
 
-	if err := d.readMiniBlockHeader(); err != nil {
-		return err
+	// If we only have 1 value, there are no deltas to decode, so skip miniblock header
+	if d.valuesCount > 1 {
+		if err := d.readMiniBlockHeader(); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -98,6 +101,7 @@ func (d *deltaBitPackDecoder32) readMiniBlockHeader() error {
 		return fmt.Errorf("not enough data to read all miniblock bit widths: %w", err)
 	}
 
+	// Validate bit widths to be defensive (we also check at array access time)
 	for i := range d.miniBlockBitWidth {
 		if d.miniBlockBitWidth[i] > 32 {
 			return fmt.Errorf("invalid miniblock bit width: %d", d.miniBlockBitWidth[i])
@@ -116,6 +120,13 @@ func (d *deltaBitPackDecoder32) next() (int32, error) {
 		return 0, io.EOF
 	}
 
+	// Special case: if we only have 1 value, just return it (no deltas to read)
+	if d.valuesCount == 1 {
+		ret := d.previousValue
+		d.position++
+		return ret, nil
+	}
+
 	// need new byte?
 	if d.position%8 == 0 {
 		// do we need to advance a mini block?
@@ -128,6 +139,12 @@ func (d *deltaBitPackDecoder32) next() (int32, error) {
 			}
 
 			d.currentMiniBlockBitWidth = d.miniBlockBitWidth[d.currentMiniBlock]
+
+			// Validate bit width is within bounds before using it as array index
+			if int(d.currentMiniBlockBitWidth) >= len(unpack8Int32FuncByWidth) {
+				return 0, fmt.Errorf("invalid miniblock bit width: %d (max supported: %d)", d.currentMiniBlockBitWidth, len(unpack8Int32FuncByWidth)-1)
+			}
+
 			d.currentUnpacker = unpack8Int32FuncByWidth[int(d.currentMiniBlockBitWidth)]
 
 			d.miniBlockPosition = 0
@@ -200,8 +217,11 @@ func (d *deltaBitPackDecoder64) init(r io.Reader) error {
 		return err
 	}
 
-	if err := d.readMiniBlockHeader(); err != nil {
-		return err
+	// If we only have 1 value, there are no deltas to decode, so skip miniblock header
+	if d.valuesCount > 1 {
+		if err := d.readMiniBlockHeader(); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -257,6 +277,7 @@ func (d *deltaBitPackDecoder64) readMiniBlockHeader() error {
 		return fmt.Errorf("not enough data to read all miniblock bit widths: %w", err)
 	}
 
+	// Validate bit widths as defense-in-depth (we also check at array access time)
 	for i := range d.miniBlockBitWidth {
 		if d.miniBlockBitWidth[i] > 64 {
 			return fmt.Errorf("invalid miniblock bit width: %d", d.miniBlockBitWidth[i])
@@ -275,6 +296,13 @@ func (d *deltaBitPackDecoder64) next() (int64, error) {
 		return 0, io.EOF
 	}
 
+	// Special case: if we only have 1 value, just return it (no deltas to read)
+	if d.valuesCount == 1 {
+		ret := d.previousValue
+		d.position++
+		return ret, nil
+	}
+
 	// need new byte?
 	if d.position%8 == 0 {
 		// do we need to advance a mini block?
@@ -287,6 +315,12 @@ func (d *deltaBitPackDecoder64) next() (int64, error) {
 			}
 
 			d.currentMiniBlockBitWidth = d.miniBlockBitWidth[d.currentMiniBlock]
+
+			// Validate bit width is within bounds before using it as array index
+			if int(d.currentMiniBlockBitWidth) >= len(unpack8Int64FuncByWidth) {
+				return 0, fmt.Errorf("invalid miniblock bit width: %d (max supported: %d)", d.currentMiniBlockBitWidth, len(unpack8Int64FuncByWidth)-1)
+			}
+
 			d.currentUnpacker = unpack8Int64FuncByWidth[int(d.currentMiniBlockBitWidth)]
 
 			d.miniBlockPosition = 0

--- a/page_v2_test.go
+++ b/page_v2_test.go
@@ -1,0 +1,56 @@
+package goparquet
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/fraugster/parquet-go/parquet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDataReaderV2_Read(t *testing.T) {
+	pageHeader := &parquet.PageHeader{
+		CompressedPageSize:   3,
+		UncompressedPageSize: 3,
+		DataPageHeaderV2: &parquet.DataPageHeaderV2{
+			NumValues:                  5,
+			RepetitionLevelsByteLength: 0,
+			DefinitionLevelsByteLength: 0,
+			NumRows:                    5,
+			Encoding:                   parquet.Encoding_PLAIN,
+			IsCompressed:               false,
+		},
+	}
+
+	mockReader := bytes.NewReader([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+	mockDecoder := &mockValuesDecoder{}
+
+	// Create the data page (v2) reader
+	reader := &dataPageReaderV2{
+		ph:          pageHeader,
+		alloc:       newAllocTracker(100),
+		valuesCount: 5,
+		position:    0,
+		fn: func(parquet.Encoding) (valuesDecoder, error) {
+			return mockDecoder, nil
+		},
+	}
+
+	err := reader.read(mockReader, pageHeader, parquet.CompressionCodec_SNAPPY, false)
+	require.NoError(t, err)
+}
+
+type mockValuesDecoder struct {
+	r io.Reader
+}
+
+func (m *mockValuesDecoder) init(reader io.Reader) error {
+	m.r = reader
+	return nil
+}
+
+func (m *mockValuesDecoder) decodeValues(_ []interface{}) (int, error) {
+	// We don't need to implement this
+	return 0, nil
+}


### PR DESCRIPTION
[This is a sync of a [fix already done and tested in a fork](https://github.com/panther-labs/parquet-go/pull/1)]

Relates to https://github.com/fraugster/parquet-go/issues/102

### Context 

Panther is running [fraugster/parguet-go](https://github.com/fraugster/parquet-go/) in production for some months now ingesting TBs of data.

Some customers reported that they got the following error:
```
snappy: corrupt input
```

After some investigation we can see that in the `read` function of the the V2 DataPage, the flag (already present in `DataPageHeaderV2`) was not checked.

More context: Parquet files - when compressed - are so in the page layer. Parquet supports compression _per page_, (as shown from the `DataPageHeaderV2` `IsCompressed` field, which comes directly from the thrift definition). The library detects the compression type (called `CompressionCodec`) and passes that down to the [`newBlockReader` level](https://github.com/panther-labs/parquet-go/blob/0c50c9da7cd7835c30640c7f51401547bf79d30f/compress.go#L102). However it still needs to check if that specific page is indeed compressed, and that was missing.

### Checks

FWIW, I doubled check this with [parquet-go/parquet-goparquet-go/parquet-go](https://github.com/parquet-go/parquet-go) and confirmed that they don't try to decompress that.

- [x] Unit tests added
- [x] Full test run (and screenshot)
- [x] Run all unit tests with the race detector on
- [x] Run the linters locally via golangci-lint run

**Ran all the tests with https://github.com/apache/parquet-testing**

![image](https://github.com/panther-labs/parquet-go/assets/777619/873ff0c1-6daa-44da-8e35-3395bb4698b5)

[Note: I can try adding a file into https://github.com/apache/parquet-testing before trying merging this into upstream]

**Ran all unit tests with the race detector on**

![image](https://github.com/panther-labs/parquet-go/assets/777619/403ef582-b4c9-4699-8119-efff0074aabf)

**Added a unit tests**
... that passes with false, but breaks if I do `IsCompressed` => `true` because the input is not snappy